### PR TITLE
Fix PID field indexes

### DIFF
--- a/lib/segments/pid.rb
+++ b/lib/segments/pid.rb
@@ -3,16 +3,16 @@ require 'ruby-hl7'
 class HL7::Message::Segment::PID < HL7::Message::Segment
   weight 1
   has_children [:NK1,:NTE,:PV1,:PV2]
-  add_field :set_id, :idx => 0
-  add_field :patient_id, :idx => 1
-  add_field :patient_id_list, :idx => 2
-  add_field :alt_patient_id, :idx => 3
-  add_field :patient_name, :idx => 4
-  add_field :mother_maiden_name, :idx => 5
-  add_field :patient_dob, :idx => 6 do |value|
+  add_field :set_id
+  add_field :patient_id
+  add_field :patient_id_list
+  add_field :alt_patient_id
+  add_field :patient_name
+  add_field :mother_maiden_name
+  add_field :patient_dob do |value|
     convert_to_ts(value)
   end
-  add_field :admin_sex, :idx => 7 do |sex|
+  add_field :admin_sex do |sex|
     unless /^[FMOUANC]$/.match(sex) || sex == nil || sex == ""
       raise HL7::InvalidDataError.new( "bad administrative sex value (not F|M|O|U|A|N|C)" )
     end
@@ -30,7 +30,8 @@ class HL7::Message::Segment::PID < HL7::Message::Segment
   add_field :religion
   add_field :account_number
   add_field :social_security_num
-  add_field :mothers_id, :idx => 21
+  add_field :driver_license_num
+  add_field :mothers_id
   add_field :ethnic_group
   add_field :birthplace
   add_field :multi_birth

--- a/spec/pid_segment_spec.rb
+++ b/spec/pid_segment_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe HL7::Message::Segment::PID do
   context 'general' do
     before :all do
-      @base = "PID|||333||LastName^FirstName^MiddleInitial^SR^NickName||19760228|F||||||||||555. 55|012345678||||||||||201011110924-0700|Y"
+      @base = "PID|1||333||LastName^FirstName^MiddleInitial^SR^NickName||19760228|F||2106-3^White^HL70005^CAUC^Caucasian^L||||||||555.55|012345678||||||||||201011110924-0700|Y|||||||||"
     end
 
     it 'validates the admin_sex element' do
@@ -22,13 +22,49 @@ describe HL7::Message::Segment::PID do
           pid.admin_sex = x
         end
       end.should raise_error(HL7::InvalidDataError)
-
     end
 
-    it 'supports death fields' do
+    it "sets values correctly" do
       pid = HL7::Message::Segment::PID.new @base
-      pid.death_date.should == '201011110924-0700'
-      pid.death_indicator.should == 'Y'
+      pid.set_id.should == "1"
+      pid.patient_id.should == ""
+      pid.patient_id_list.should == "333"
+      pid.alt_patient_id.should == ""
+      pid.patient_name.should == "LastName^FirstName^MiddleInitial^SR^NickName"
+      pid.mother_maiden_name.should == ""
+      pid.patient_dob.should == "19760228"
+      pid.admin_sex.should == "F"
+      pid.patient_alias.should == ""
+      pid.race.should == "2106-3^White^HL70005^CAUC^Caucasian^L"
+      pid.address.should == ""
+      pid.country_code.should == ""
+      pid.phone_home.should == ""
+      pid.phone_business.should == ""
+      pid.primary_language.should == ""
+      pid.marital_status.should == ""
+      pid.religion.should == ""
+      pid.account_number.should == "555.55"
+      pid.social_security_num.should == "012345678"
+      pid.driver_license_num.should == ""
+      pid.mothers_id.should == ""
+      pid.ethnic_group.should == ""
+      pid.birthplace.should == ""
+      pid.multi_birth.should == ""
+      pid.birth_order.should == ""
+      pid.citizenship.should == ""
+      pid.vet_status.should == ""
+      pid.nationality.should == ""
+      pid.death_date.should == "201011110924-0700"
+      pid.death_indicator.should == "Y"
+      pid.id_unknown_indicator.should == ""
+      pid.id_readability_code.should == ""
+      pid.last_update_date.should == ""
+      pid.last_update_facility.should == ""
+      pid.species_code.should == ""
+      pid.breed_code.should == ""
+      pid.strain.should == ""
+      pid.production_class_code.should == ""
+      pid.tribal_citizenship.should == ""
     end
   end
 end


### PR DESCRIPTION
The indexes for the PID were off by 1 such that if you tried to call method like `patient_dob` you would get the value for previous element.

This commit fixes this issue and adds a full test for all values of a PID.
