### PR TITLE
Change TravisCI ruby dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ rvm:
   - 1.9.3
   - ruby-head
   - jruby-19mode # JRuby in 1.9 mode
+  - rbx-2.2


### PR DESCRIPTION
The rbx-19 combat mode is no longer a valid config setting so the build errors out.

Since people have worked on rbx compatibility, I changed that up and added in 2.0 and 2.1 support on MRI.
