### PR TITLE
Adding 'alias-field' method for segments

### DIFF
--- a/lib/segment_fields.rb
+++ b/lib/segment_fields.rb
@@ -56,6 +56,24 @@ module HL7::Message::SegmentFields
         (@fields ||= [])
       end
     end
+
+    def alias_field(new_field_name, old_field_name)
+      self.class_eval <<-END
+        def #{new_field_name}(val=nil)
+          raise HL7::InvalidDataError.new unless self.class.fields[:#{old_field_name}]
+          unless val
+            read_field( :#{old_field_name} )
+          else
+            write_field( :#{old_field_name}, val )
+            val # this matches existing n= method functionality
+          end
+        end
+
+        def #{new_field_name}=(value)
+          write_field( :#{old_field_name}, value )
+        end
+      END
+    end
   end
 
   def field_info( name ) #:nodoc:

--- a/spec/segment_field_spec.rb
+++ b/spec/segment_field_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 class MockSegment < HL7::Message::Segment
   weight 1
   add_field :no_block
+  alias_field :no_block_alias, :no_block
   add_field :validating do |value|
     value == "bad" ? nil : value
   end
@@ -59,6 +60,33 @@ describe HL7::Message::Segment do
 
       msg.e3 = "empty"
       msg.e3.should == "empty"
+    end
+  end
+
+  describe '#alias_field' do
+    context 'with a valid field' do
+      it 'uses alias field names' do
+        msg = MockSegment.new(@base)
+        msg.no_block.should == "no_block"
+        msg.no_block_alias.should == "no_block"
+      end
+    end
+
+    context 'with an invalid field' do
+
+      class MockInvalidSegment < HL7::Message::Segment
+        weight 1
+        add_field :no_block
+        alias_field :no_block_alias, :invalid_field
+        add_field :second
+        add_field :third
+      end
+
+
+      it 'throws an error when the field is invalid' do
+        msg = MockInvalidSegment.new(@base)
+        lambda{  msg.no_block_alias }.should raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds the `alias-field` functionality which is required to fix #14 .

The method `alias-field` would work like this:

``` ruby
class MockSegment < HL7::Message::Segment
   weight 1
   add_field :no_block
   alias_field :no_block_alias, :no_block
   add_field :validating do |value|
     value == "bad" ? nil : value
   end
end

base = "Mock|no_block|validated|converted"
msg = MockSegment.new(base)
msg.no_block        #output => "no_block"
msg.no_block_alias  #output => "no_block"
```

Hey @rojotek, @Stratus3D, @jgn Would you mind taking a look at this?
