### PR TITLE
Adding "correction?" method to HL7 message and OBX segment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ rvm:
   - 2.0.0
   - 1.9.3
   - ruby-head
-  - jruby-19mode # JRuby in 1.9 mode
-  - rbx-2.2
+  - jruby-9.0.4.0
+  - rbx-3.9

--- a/lib/message.rb
+++ b/lib/message.rb
@@ -196,6 +196,11 @@ class HL7::Message
     end
   end
 
+  # Checks if any of the results is a correction
+  def correction?
+    Array.new(self[:OBX]).map(&:correction?).any?
+  end
+
   private
   def generate_segments( ary )
     raise HL7::ParseError.new( "no array to generate segments" ) unless ary.length > 0

--- a/lib/message.rb
+++ b/lib/message.rb
@@ -198,7 +198,7 @@ class HL7::Message
 
   # Checks if any of the results is a correction
   def correction?
-    Array.new(self[:OBX]).map(&:correction?).any?
+    Array(self[:OBX]).any?(&:correction?)
   end
 
   private

--- a/lib/segments/obx.rb
+++ b/lib/segments/obx.rb
@@ -34,5 +34,8 @@ class HL7::Message::Segment::OBX < HL7::Message::Segment
   add_field :performing_organization_name
   add_field :performing_organization_address
   add_field :performing_organization_medical_director
-end
 
+  def correction?
+    observation_result_status == "C"
+  end
+end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe HL7::Message do
+  describe "#correction?" do
+    let(:hl7) { HL7::Message.new data  }
+    subject { hl7.correction? }
+
+    context "when is a correction" do
+      let(:data) {
+        [
+          'OBR|1|A241Z^LAB||123456^A TEST^L|||201508181431||1234||||None|201502181432||||OMG123||||20150818143300',         # "F" final
+          'OBX|1|ST|123456^AA OBSERVATION^L^4567890^FIRST OBSERVATION^LN||42|ug/dL^Micrograms per Deciliter^UCUM|<10 ug/dL|H|||F||||OMG',
+          'NTE|1||SOME',
+          'NTE|2||THOUGHTS',
+          'OBR|2|A241Z^LAB||123456^A TEST^L|||201508181431||1234||||None|201502181432||||OMG123||||20150818143300',         # "C" corrected
+          'OBX|1|ST|123456^AA OBSERVATION^L^4567890^FIRST OBSERVATION^LN||42|ug/dL^Micrograms per Deciliter^UCUM|<10 ug/dL|H|||C||||OMG',
+          'NTE|1||SOME',
+          'NTE|2||THOUGHTS',
+        ].join("\r")
+      }
+
+      it { is_expected.to be true }
+    end
+
+    context "when is not a correction" do
+      let(:data) {
+        [
+          'OBR|1|A241Z^LAB||123456^A TEST^L|||201508181431||1234||||None|201502181432||||OMG123||||20150818143300',         # "F" final
+          'OBX|1|ST|123456^AA OBSERVATION^L^4567890^FIRST OBSERVATION^LN||42|ug/dL^Micrograms per Deciliter^UCUM|<10 ug/dL|H|||F||||OMG',
+          'NTE|1||SOME',
+          'NTE|2||THOUGHTS',
+          'OBR|2|A241Z^LAB||123456^A TEST^L|||201508181431||1234||||None|201502181432||||OMG123||||20150818143300',         # "F" final
+          'OBX|1|ST|123456^AA OBSERVATION^L^4567890^FIRST OBSERVATION^LN||42|ug/dL^Micrograms per Deciliter^UCUM|<10 ug/dL|H|||F||||OMG',
+          'NTE|1||SOME',
+          'NTE|2||THOUGHTS',
+        ].join("\r")
+      }
+
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -38,5 +38,16 @@ describe HL7::Message do
 
       it { is_expected.to be false }
     end
+
+    context "when there are no results (OBX) segments" do
+      let(:data) {
+        [
+          'OBR|1|A241Z^LAB||123456^A TEST^L|||201508181431||1234||||None|201502181432||||OMG123||||20150818143300',
+          'OBR|2|A241Z^LAB||123456^A TEST^L|||201508181431||1234||||None|201502181432||||OMG123||||20150818143300'
+        ].join("\r")
+      }
+
+      it { is_expected.to be false }
+    end
   end
 end

--- a/spec/obx_segment_spec.rb
+++ b/spec/obx_segment_spec.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 require 'spec_helper'
+
 describe HL7::Message::Segment::OBX do
   context 'general' do
     before :all do
@@ -41,6 +42,27 @@ describe HL7::Message::Segment::OBX do
         obx.observation_sub_id = "2"
         obx.observation_value = "SOMETHING HAPPENned"
       end.should_not raise_error
+    end
+
+    describe "#correction?" do
+      let(:obx) { HL7::Message::Segment::OBX.new data  }
+      subject { obx.correction? }
+
+      context "when is a correction" do
+        let(:data) {
+          'OBX|1|ST|123456^AA OBSERVATION^L^4567890^FIRST OBSERVATION^LN||42|ug/dL^Micrograms per Deciliter^UCUM|<10 ug/dL|H|||C||||OMG'
+        }
+
+        it { is_expected.to be true }
+      end
+
+      context "when is not a correction" do
+        let(:data) {
+          'OBX|1|ST|123456^AA OBSERVATION^L^4567890^FIRST OBSERVATION^LN||42|ug/dL^Micrograms per Deciliter^UCUM|<10 ug/dL|H|||F||||OMG'
+        }
+
+        it { is_expected.to be false }
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #51 

The idea is to have a `correction?` method that you can call on the HL7 message or the OBX segment.

Thanks @clausti and @adamstegman for the feedback and the initial idea.