### PR TITLE
Enumerable elements from segment

### DIFF
--- a/lib/segment.rb
+++ b/lib/segment.rb
@@ -144,6 +144,12 @@ class HL7::Message::Segment
     @is_child_segment = val
   end
 
+  # yield each element in the segment
+  def each # :yields: element
+    return unless @elements
+    @elements.each { |e| yield e }
+  end
+
   # get the length of the segment (number of fields it contains)
   def length
     0 unless @elements

--- a/spec/segment_spec.rb
+++ b/spec/segment_spec.rb
@@ -9,6 +9,17 @@ describe HL7::Message::Segment do
     end
   end
 
+  describe 'enumerable' do
+    it 'enumerates over elements' do
+      seg = HL7::Message::Segment::Default.new
+      segment_count = 0
+      seg.each do |s|
+        segment_count = segment_count + 1
+      end
+      segment_count.should == seg.length
+    end
+  end
+
   describe 'is_child_segment?' do
     let(:segment){ HL7::Message::Segment.new "MSA|AR|ZZ9380 ERR" }
     it "return false when is not set" do


### PR DESCRIPTION
Make segments enumerable on their elements. Added test to compare enumerable elements with segment.length.

Issue: https://github.com/ruby-hl7/ruby-hl7/issues/55