### PR TITLE
Update the SFT Segment

### DIFF
--- a/lib/segments/sft.rb
+++ b/lib/segments/sft.rb
@@ -1,11 +1,5 @@
 class HL7::Message::Segment::SFT < HL7::Message::Segment
   weight 0
-  # The sample SFT segments seem to have Set ID before SFT-1, software
-  # vendor organization.  This is sensible, since each software
-  # component that retransmits a message is supposed to add its own SFT
-  # segment.  A Set ID is required to distinguish among multiple SFT
-  # segments.
-  add_field :set_id
   add_field :software_vendor_organization
   add_field :software_certified_version_or_release_number # NEW longest method name ever.
   add_field :software_product_name

--- a/spec/sft_segment_spec.rb
+++ b/spec/sft_segment_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe HL7::Message::Segment::SFT do
   context 'general' do
     before :all do
-      @base_sft = 'SFT|1|Level Seven Healthcare Software, Inc.^L^^^^&2.16.840.1.113883.19.4.6^ISO^XX^^^1234|1.2|An Lab System|56734||20080817'
+      @base_sft = 'SFT|Level Seven Healthcare Software, Inc.^L^^^^&2.16.840.1.113883.19.4.6^ISO^XX^^^1234|1.2|An Lab System|56734||20080817'
     end
 
     it 'creates an SFT segment' do


### PR DESCRIPTION
Removing the set id from the SFT segment.  It does not exist in the HL7 specifications version 2.5.1 or in any other reference I could find online.

http://hl7-definition.caristix.com:9010/Default.aspx?version=HL7%20v2.5.1&segment=SFT
https://www.mnhospitals.org/Portals/0/Documents/data-reporting/ahrq/implementation_guide_elab_rptg.pdf