### PR TITLE
Add termination char to every segment, even the last one.

### DIFF
--- a/lib/message.rb
+++ b/lib/message.rb
@@ -168,7 +168,7 @@ class HL7::Message
 
   # provide a HL7 spec version of the message
   def to_hl7
-    @segments.collect { |s| s if s.to_s.length > 0 }.join( @delimiter.segment )
+    @segments.collect { |s| "#{s}#{@delimiter.segment}" if s.to_s.length > 0 }.join
   end
 
   # provide the HL7 spec version of the message wrapped in MLLP


### PR DESCRIPTION
HL7 Inspector notifies:
> Warning: Last segment have no segment termination char 0x0d !

The to_hl7 - and then to_mllp - methods does not terminate the last segment.

HL7 specification says that every segment should be terminated, even the last one.
With this simple PR every segment is terminated.