### PR TITLE
Segment element array accessor

### DIFF
--- a/lib/segment_fields.rb
+++ b/lib/segment_fields.rb
@@ -88,6 +88,14 @@ module HL7::Message::SegmentFields
     [ idx, field_blk ]
   end
 
+  def []( index )
+    @elements[index]
+  end
+
+  def []=( index, value )
+    @elements[index] = value.to_s
+  end
+
   def read_field( name ) #:nodoc:
     idx, field_blk = field_info( name )
     return nil unless idx

--- a/spec/segment_field_spec.rb
+++ b/spec/segment_field_spec.rb
@@ -63,6 +63,24 @@ describe HL7::Message::Segment do
     end
   end
 
+  describe '#[]' do
+    it 'allows index access to the segment' do
+      msg = HL7::Message::Segment.new(@base)
+      msg[0].should == 'Mock'
+      msg[1].should == 'no_block'
+      msg[2].should == 'validated'
+      msg[3].should == 'converted'
+    end
+  end
+
+  describe '#[]=' do
+    it 'allows index assignment to the segment' do
+      msg = HL7::Message::Segment.new(@base)
+      msg[0] = 'Kcom'
+      expect(msg[0]).to eq 'Kcom'
+    end
+  end
+
   describe '#alias_field' do
     context 'with a valid field' do
       it 'uses alias field names' do


### PR DESCRIPTION
Add an array accessor to segments.  Useful when the segment is not defined so named accessors are not an option.