### PR TITLE
Add DG1 and ZPS segments

### DIFF
--- a/lib/message.rb
+++ b/lib/message.rb
@@ -47,7 +47,7 @@ class HL7::Message
     @segments_by_name = {}
     @item_delim = "^"
     @element_delim = '|'
-    @segment_delim = "\n"
+    @segment_delim = "\r"
     @delimiter = HL7::Message::Delimiter.new( @element_delim,
                                               @item_delim,
                                               @segment_delim)

--- a/lib/message.rb
+++ b/lib/message.rb
@@ -47,7 +47,7 @@ class HL7::Message
     @segments_by_name = {}
     @item_delim = "^"
     @element_delim = '|'
-    @segment_delim = "\r"
+    @segment_delim = "\n"
     @delimiter = HL7::Message::Delimiter.new( @element_delim,
                                               @item_delim,
                                               @segment_delim)

--- a/lib/segments/dg1.rb
+++ b/lib/segments/dg1.rb
@@ -10,14 +10,14 @@ module HL7
     add_field :diagnosis_related_group,   :idx => 7
     add_field :drg_approval_indicator,    :idx => 8
     add_field :drg_grouper_review_code,   :idx => 9
-    add_field :outlier_type,              :idx => 9
-    add_field :outlier_days,              :idx => 9
-    add_field :outlier_cost,              :idx => 9
-    add_field :grouper_version_and_type,  :idx => 9
-    add_field :diagnosis_priority,        :idx => 9
-    add_field :diagnosis_clinician,       :idx => 9
-    add_field :diagnosis_classification,  :idx => 9
-    add_field :confidential_indicator,    :idx => 9
-    add_field :attestation_date_time,     :idx => 9
+    add_field :outlier_type,              :idx => 10
+    add_field :outlier_days,              :idx => 11
+    add_field :outlier_cost,              :idx => 12
+    add_field :grouper_version_and_type,  :idx => 13
+    add_field :diagnosis_priority,        :idx => 14
+    add_field :diagnosis_clinician,       :idx => 15
+    add_field :diagnosis_classification,  :idx => 16
+    add_field :confidential_indicator,    :idx => 17
+    add_field :attestation_date_time,     :idx => 18
   end
 end

--- a/lib/segments/dg1.rb
+++ b/lib/segments/dg1.rb
@@ -1,0 +1,23 @@
+module HL7
+  class Message::Segment::DG1 < HL7::Message::Segment
+    weight 92
+    add_field :set_id,                    :idx => 1
+    add_field :diagnosis_coding_method,   :idx => 2
+    add_field :diagnosis_code,            :idx => 3
+    add_field :diagnosis_date_time,       :idx => 4
+    add_field :diagnosis_type,            :idx => 5
+    add_field :major_diagnostic_category, :idx => 6
+    add_field :diagnosis_related_group,   :idx => 7
+    add_field :drg_approval_indicator,    :idx => 8
+    add_field :drg_grouper_review_code,   :idx => 9
+    add_field :outlier_type,              :idx => 9
+    add_field :outlier_days,              :idx => 9
+    add_field :outlier_cost,              :idx => 9
+    add_field :grouper_version_and_type,  :idx => 9
+    add_field :diagnosis_priority,        :idx => 9
+    add_field :diagnosis_clinician,       :idx => 9
+    add_field :diagnosis_classification,  :idx => 9
+    add_field :confidential_indicator,    :idx => 9
+    add_field :attestation_date_time,     :idx => 9
+  end
+end

--- a/lib/segments/dg1.rb
+++ b/lib/segments/dg1.rb
@@ -1,26 +1,26 @@
 module HL7
   class Message::Segment::DG1 < HL7::Message::Segment
     weight 92
-    add_field :set_id,                    :idx => 1
-    add_field :diagnosis_coding_method,   :idx => 2
-    add_field :diagnosis_code,            :idx => 3
-    add_field :diagnosis_date_time,       :idx => 4 do |value|
+    add_field :set_id
+    add_field :diagnosis_coding_method
+    add_field :diagnosis_code
+    add_field :diagnosis_date_time do |value|
       convert_to_ts(value)
     end
-    add_field :diagnosis_type,            :idx => 5
-    add_field :major_diagnostic_category, :idx => 6
-    add_field :diagnosis_related_group,   :idx => 7
-    add_field :drg_approval_indicator,    :idx => 8
-    add_field :drg_grouper_review_code,   :idx => 9
-    add_field :outlier_type,              :idx => 10
-    add_field :outlier_days,              :idx => 11
-    add_field :outlier_cost,              :idx => 12
-    add_field :grouper_version_and_type,  :idx => 13
-    add_field :diagnosis_priority,        :idx => 14
-    add_field :diagnosis_clinician,       :idx => 15
-    add_field :diagnosis_classification,  :idx => 16
-    add_field :confidential_indicator,    :idx => 17
-    add_field :attestation_date_time,     :idx => 18 do |value|
+    add_field :diagnosis_type
+    add_field :major_diagnostic_category
+    add_field :diagnosis_related_group
+    add_field :drg_approval_indicator
+    add_field :drg_grouper_review_code
+    add_field :outlier_type
+    add_field :outlier_days
+    add_field :outlier_cost
+    add_field :grouper_version_and_type
+    add_field :diagnosis_priority
+    add_field :diagnosis_clinician
+    add_field :diagnosis_classification
+    add_field :confidential_indicator
+    add_field :attestation_date_time do |value|
       convert_to_ts(value)
     end
     

--- a/lib/segments/dg1.rb
+++ b/lib/segments/dg1.rb
@@ -4,7 +4,9 @@ module HL7
     add_field :set_id,                    :idx => 1
     add_field :diagnosis_coding_method,   :idx => 2
     add_field :diagnosis_code,            :idx => 3
-    add_field :diagnosis_date_time,       :idx => 4
+    add_field :diagnosis_date_time,       :idx => 4 do |value|
+      convert_to_ts(value)
+    end
     add_field :diagnosis_type,            :idx => 5
     add_field :major_diagnostic_category, :idx => 6
     add_field :diagnosis_related_group,   :idx => 7
@@ -18,6 +20,18 @@ module HL7
     add_field :diagnosis_clinician,       :idx => 15
     add_field :diagnosis_classification,  :idx => 16
     add_field :confidential_indicator,    :idx => 17
-    add_field :attestation_date_time,     :idx => 18
+    add_field :attestation_date_time,     :idx => 18 do |value|
+      convert_to_ts(value)
+    end
+    
+    private
+    
+    def self.convert_to_ts(value) #:nodoc:
+      if value.is_a?(Time) or value.is_a?(Date)
+        value.to_hl7
+      else
+        value
+      end
+    end
   end
 end

--- a/lib/segments/zps.rb
+++ b/lib/segments/zps.rb
@@ -1,0 +1,12 @@
+class HL7::Message::Segment::ZPS < HL7::Message::Segment
+    weight 12
+    add_field :set_id,                  :idx => 1
+    add_field :facility_footnote_code,  :idx => 2
+    add_field :facility_name,           :idx => 3
+    add_field :facility_address,        :idx => 4
+    add_field :facility_phone_number,   :idx => 5
+    add_field :facility_contact,        :idx => 6
+    add_field :facility_director,       :idx => 7
+    add_field :facility_lab_code,       :idx => 8
+    add_field :facility_clia_number,    :idx => 9
+  end


### PR DESCRIPTION
### Context

Adding DG1 per field names found here: http://hl7api.sourceforge.net/v231/apidocs/ca/uhn/hl7v2/model/v231/segment/DG1.html. Please point me a better source if a better source is required.

Adding ZPS segment per "https://github.com/ruby-hl7/ruby-hl7-zps". Seemed odd for it to be a gem by itself so I brought it in.

Will add tests shortly and feedback is highly appreciated. I love that this gem exists! 
