### PR TITLE
Add diagnosis_description to DG1 per HL7 Docs

### DIFF
--- a/lib/segments/dg1.rb
+++ b/lib/segments/dg1.rb
@@ -4,6 +4,7 @@ module HL7
     add_field :set_id
     add_field :diagnosis_coding_method
     add_field :diagnosis_code
+    add_field :diagnosis_description
     add_field :diagnosis_date_time do |value|
       convert_to_ts(value)
     end
@@ -23,9 +24,9 @@ module HL7
     add_field :attestation_date_time do |value|
       convert_to_ts(value)
     end
-    
+
     private
-    
+
     def self.convert_to_ts(value) #:nodoc:
       if value.is_a?(Time) || value.is_a?(Date)
         value.to_hl7

--- a/spec/dg1_spec.rb
+++ b/spec/dg1_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 describe HL7::Message::Segment::DG1 do
   context "reading" do
     let(:base_string) do
-      "DG1|1|I9|71596^OSTEOARTHROS NOS-L/LEG ^I9|OSTEOARTHROS NOS-L/LEG ||A|"
+      "DG1|1|I9|71596^OSTEOARTHROS NOS-L/LEG ^I9|OSTEOARTHROS NOS-L/LEG |20170615140551-0800||A|"
     end
     let(:segment){ HL7::Message::Segment::DG1.new(base_string) }
 
@@ -12,7 +12,8 @@ describe HL7::Message::Segment::DG1 do
       expect(segment.set_id).to eq("1")
       expect(segment.diagnosis_coding_method).to eq("I9")
       expect(segment.diagnosis_code).to eq("71596^OSTEOARTHROS NOS-L/LEG ^I9")
-      expect(segment.diagnosis_date_time).to eq("OSTEOARTHROS NOS-L/LEG ")
+      expect(segment.diagnosis_description).to eq("OSTEOARTHROS NOS-L/LEG ")
+      expect(segment.diagnosis_date_time).to eq("20170615140551-0800")
       expect(segment.diagnosis_type).to eq("")
       expect(segment.major_diagnostic_category).to eq("A")
       expect(segment.diagnosis_related_group).to eq("")


### PR DESCRIPTION
Added diagnosis_description (DG1.4) per the HL7 Docs here: http://hl7-definition.caristix.com:9010/HL7%20v2.3.1/segment/DG1

Before, date_time (DG1.5) was being used to gather description information and all other fields were being offset by 1.