### PR TITLE
Move rubyforge gem to development dependencies from runtime dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@ source 'https://rubygems.org'
 
 gem 'rake', '~> 11.0'
 gem 'rdoc'
-gem 'rubyforge'
 gem 'technicalpickles-jeweler'
 
 group :test, :development do
   gem 'simplecov'
   gem 'rspec', '~> 2.99.0'
+  gem 'rubyforge'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -72,7 +72,7 @@ spec = Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.8.6'
   s.extra_rdoc_files = %w[README.rdoc LICENSE]
   s.add_dependency("rake", ">= #{RAKEVERSION}")
-  s.add_dependency("rubyforge", ">= #{::RubyForge::VERSION}")
+  s.add_development_dependency("rubyforge", ">= #{::RubyForge::VERSION}")
 end
 
 desc "Run all examples"

--- a/ruby-hl7.gemspec
+++ b/ruby-hl7.gemspec
@@ -32,13 +32,13 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rake>, [">= 10.0.0"])
-      s.add_runtime_dependency(%q<rubyforge>, [">= 2.0.4"])
+      s.add_development_dependency(%q<rubyforge>, [">= 2.0.4"])
     else
       s.add_dependency(%q<rake>, [">= 10.0.0"])
-      s.add_dependency(%q<rubyforge>, [">= 2.0.4"])
+      s.add_development_dependency(%q<rubyforge>, [">= 2.0.4"])
     end
   else
     s.add_dependency(%q<rake>, [">= 10.0.0"])
-    s.add_dependency(%q<rubyforge>, [">= 2.0.4"])
+    s.add_development_dependency(%q<rubyforge>, [">= 2.0.4"])
   end
 end


### PR DESCRIPTION
RubyForge is only used in Rakefile.

However, rubyforge gem is not under maintenance.
I think dependency on rubyforge gem should be deleted in the next step.

Thank you.