### PR TITLE
Add AIL segment to ruby-hl7

### DIFF
--- a/lib/segments/ail.rb
+++ b/lib/segments/ail.rb
@@ -1,0 +1,15 @@
+class HL7::Message::Segment::AIL < HL7::Message::Segment
+    weight 0
+    add_field :set_id
+    add_field :segment_action_code
+    add_field :location_resource_id
+    add_field :location_type
+    add_field :location_group
+    add_field :start_date_time
+    add_field :start_date_time_offset
+    add_field :start_date_time_offset_units
+    add_field :duration
+    add_field :duration_units
+    add_field :allow_substitution_code
+    add_field :filler_status_code
+  end

--- a/spec/ail_segment_spec.rb
+++ b/spec/ail_segment_spec.rb
@@ -1,0 +1,28 @@
+# encoding: UTF-8
+require 'spec_helper'
+
+describe HL7::Message::Segment::AIL do
+  context 'general' do
+    before :all do
+      @base_ail = 'AIL|1|A|OFFICE^^^OFFICE|^OFFICE^A4'
+    end
+
+    it 'creates an AIL segment' do
+      lambda do
+        ail = HL7::Message::Segment::AIL.new( @base_ail )
+        ail.should_not be_nil
+        ail.to_s.should eq @base_ail
+      end.should_not raise_error
+    end
+
+    it 'allows access to an AIL segment' do
+      lambda do
+        ail = HL7::Message::Segment::AIL.new( @base_ail )
+        ail.set_id.should eq '1'
+        ail.segment_action_code.should eq 'A'
+        ail.location_resource_id.should eq 'OFFICE^^^OFFICE'
+        ail.location_type.should eq '^OFFICE^A4'
+      end.should_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
Adding the standard AIL segment (Appointment Information - Location Resource) for use in scheduling message integration.
http://hl7-definition.caristix.com:9010/HL7%20v2.3.1/segment/AIL