### PR TITLE
Add AIG, AIS, MRG, RGS, TQ1 segments and add fields on SCH

### DIFF
--- a/lib/segments/aig.rb
+++ b/lib/segments/aig.rb
@@ -1,0 +1,21 @@
+class HL7::Message::Segment::AIG < HL7::Message::Segment
+  weight 1
+  add_field :set_id
+  add_field :segment_action_code
+  add_field :resource_id
+  add_field :resource_type
+  add_field :resource_group
+  add_field :resource_quantity
+  add_field :resource_quantity_units
+  add_field :start_time
+  add_field :start_time_offset
+  add_field :start_time_offset_units
+  add_field :duration
+  add_field :duration_units
+  add_field :allow_subsitution_code
+  add_field :filler_status_status
+
+  alias_field :start_date, :start_time
+  alias_field :start_date_offset, :start_time_offset
+  alias_field :start_date_offset_units, :start_time_offset_units
+end

--- a/lib/segments/ail.rb
+++ b/lib/segments/ail.rb
@@ -1,15 +1,15 @@
 class HL7::Message::Segment::AIL < HL7::Message::Segment
-    weight 0
-    add_field :set_id
-    add_field :segment_action_code
-    add_field :location_resource_id
-    add_field :location_type
-    add_field :location_group
-    add_field :start_date_time
-    add_field :start_date_time_offset
-    add_field :start_date_time_offset_units
-    add_field :duration
-    add_field :duration_units
-    add_field :allow_substitution_code
-    add_field :filler_status_code
-  end
+  weight 0
+  add_field :set_id
+  add_field :segment_action_code
+  add_field :location_resource_id
+  add_field :location_type
+  add_field :location_group
+  add_field :start_date_time
+  add_field :start_date_time_offset
+  add_field :start_date_time_offset_units
+  add_field :duration
+  add_field :duration_units
+  add_field :allow_substitution_code
+  add_field :filler_status_code
+end

--- a/lib/segments/ais.rb
+++ b/lib/segments/ais.rb
@@ -1,0 +1,19 @@
+class HL7::Message::Segment::AIS < HL7::Message::Segment
+  weight 1
+  add_field :set_id
+  add_field :segment_action_code
+  add_field :universal_service_identifier
+  add_field :start_time
+  add_field :start_time_offset
+  add_field :start_time_offset_units
+  add_field :duration
+  add_field :duration_units
+  add_field :allow_subsitution_code
+  add_field :filler_status_code
+  add_field :placer_supplemental_service_information
+  add_field :filler_supplemental_service_information
+
+  alias_field :start_date, :start_time
+  alias_field :start_date_offset, :start_time_offset
+  alias_field :start_date_offset_units, :start_time_offset_units
+end

--- a/lib/segments/mrg.rb
+++ b/lib/segments/mrg.rb
@@ -1,0 +1,10 @@
+class HL7::Message::Segment::MRG < HL7::Message::Segment
+  weight 4
+  add_field :prior_patient_identifier_list
+  add_field :prior_alternate_patient_id
+  add_field :prior_patient_account_number
+  add_field :prior_patient_id
+  add_field :prior_visit_number
+  add_field :prior_alternate_visit_id
+  add_field :prior_patient_name
+end

--- a/lib/segments/rgs.rb
+++ b/lib/segments/rgs.rb
@@ -1,0 +1,6 @@
+class HL7::Message::Segment::RGS < HL7::Message::Segment
+  weight 3
+  add_field :set_id
+  add_field :segment_action_code
+  add_field :resource_group_id
+end

--- a/lib/segments/sch.rb
+++ b/lib/segments/sch.rb
@@ -25,4 +25,6 @@ class HL7::Message::Segment::SCH < HL7::Message::Segment
   add_field :parent_placer_appointment_id
   add_field :parent_filler_appointment_id
   add_field :filler_status_code
+  add_field :placer_order_number
+  add_field :filler_order_number
 end

--- a/lib/segments/tq1.rb
+++ b/lib/segments/tq1.rb
@@ -1,0 +1,20 @@
+class HL7::Message::Segment::TQ1 < HL7::Message::Segment
+  weight 2
+  add_field :set_id
+  add_field :quantity
+  add_field :repeat_pattern
+  add_field :explicit_time
+  add_field :relative_time_and_units
+  add_field :service_duration
+  add_field :start_time
+  add_field :end_time
+  add_field :priority
+  add_field :condition_text
+  add_field :text_instruction
+  add_field :conjunction
+  add_field :occurrence_duration
+  add_field :total_occurrences
+
+  alias_field :start_date, :start_time
+  alias_field :end_date, :end_time
+end


### PR DESCRIPTION
Hi,

This PR add 5 standard segments and add 2 fields into SCH segment.
I have used HL7 v2.5.1 for the fields names.

New segments:
* [AIG](http://hl7-definition.caristix.com:9010/Default.aspx?version=HL7%20v2.5.1&segment=AIG)
* [AIS](http://hl7-definition.caristix.com:9010/Default.aspx?version=HL7%20v2.5.1&segment=AIS)
* [MRG](http://hl7-definition.caristix.com:9010/Default.aspx?version=HL7%20v2.5.1&segment=MRG)
* [RGS](http://hl7-definition.caristix.com:9010/Default.aspx?version=HL7%20v2.5.1&segment=RGS)
* [TQ1](http://hl7-definition.caristix.com:9010/Default.aspx?version=HL7%20v2.5.1&segment=TQ1)

New fields on SCH ([reference](http://hl7-definition.caristix.com:9010/Default.aspx?version=HL7%20v2.5.1&segment=SCH)):
* SCH.26 placer_order_number
* SCH.27 filler_order_number

(And also fixed a bad indentation on AIL segment)