### PR TITLE
Rspec syntax fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'rake', '~> 11.0'
-gem 'rdoc'
-gem 'technicalpickles-jeweler'
-
-group :test, :development do
-  gem 'simplecov'
-  gem 'rspec', '~> 2.99.0'
-  gem 'rubyforge'
-end
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,29 @@
+PATH
+  remote: .
+  specs:
+    ruby-hl7 (1.2.3)
+      rake (~> 11.0)
+      rdoc (~> 3.9)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.5)
-    git (1.2.5)
-    json_pure (1.5.0)
-    multi_json (1.5.0)
+    coderay (1.1.2)
+    diff-lcs (1.3)
+    docile (1.3.0)
+    ffi (1.9.23-java)
+    json (2.1.0)
+    json (2.1.0-java)
+    method_source (0.9.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry (0.11.3-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+      spoon (~> 0.0)
     rake (11.3.0)
-    rdoc (3.9.4)
+    rdoc (3.9.5)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
@@ -14,16 +31,14 @@ GEM
     rspec-core (2.99.2)
     rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.99.2)
-    rubyforge (2.0.4)
-      json_pure (>= 1.1.7)
-    simplecov (0.7.1)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.7.1)
-    simplecov-html (0.7.1)
-    technicalpickles-jeweler (1.2.1)
-      git (>= 1.2.1)
-      rubyforge
+    rspec-mocks (2.99.4)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    spoon (0.0.6)
+      ffi
 
 PLATFORMS
   java
@@ -31,12 +46,11 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
-  rake (~> 11.0)
-  rdoc
-  rspec (~> 2.99.0)
-  rubyforge
-  simplecov
-  technicalpickles-jeweler
+  bundler (~> 1.15)
+  pry
+  rspec (~> 2.99)
+  ruby-hl7!
+  simplecov (~> 0.15)
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,6 @@ require 'rdoc/task'
 require 'rubygems/package_task'
 require 'rake/contrib/sshpublisher'
 require 'rbconfig'
-require 'rubyforge'
 require 'rspec'
 require 'rspec/core/rake_task'
 require 'simplecov'
@@ -19,7 +18,6 @@ require 'segment_generator'
 require 'segment'
 
 full_name = "Ruby-HL7"
-short_name = full_name.downcase
 RAKEVERSION = 11.0
 
 # Many of these tasks were garnered from zenspider's Hoe
@@ -28,42 +26,10 @@ RAKEVERSION = 11.0
 desc 'Default: Run all examples'
 task :default => :spec
 
-if RUBY_VERSION < '1.9.1'
-  begin
-    require 'jeweler'
-    Jeweler::Tasks.new do |s|
-      s.name = short_name
-      s.full_name
-      s.summary = "Ruby HL7 Library"
-      s.authors = ["Mark Guzman"]
-      s.email = "ruby-hl7@googlegroups.com"
-      s.homepage = "http://github.com/ruby-hl7/ruby-hl7"
-      s.description = "A simple library to parse and generate HL7 2.x messages"
-      s.require_path = "lib"
-      s.has_rdoc = true
-      s.rubyforge_project = short_name
-      s.required_ruby_version = '>= 1.8.6'
-      s.extra_rdoc_files = %w[README.rdoc LICENSE]
-      s.files = FileList["{bin,lib,test_data}/**/*"].to_a
-      s.test_files = FileList["{test}/**/test*.rb"].to_a
-      s.add_dependency("rake", ">= #{RAKEVERSION}")
-    end
-  rescue LoadError
-    puts "Jeweler, or one of its dependencies, is not available. Install it with: sudo gem install jeweler"
-  end
-end
-
-
 spec = Gem::Specification.new do |s|
-  s.name = short_name
-  s.full_name
-  s.version = HL7::VERSION
-  s.author = "Mark Guzman"
-  s.email = "ruby-hl7@googlegroups.com"
   s.homepage = "https://github.com/ruby-hl7/ruby-hl7"
   s.platform = Gem::Platform::RUBY
   s.summary = "Ruby HL7 Library"
-  s.rubyforge_project = short_name
   s.description = "A simple library to parse and generate HL7 2.x messages"
   s.files = FileList["{bin,lib,test_data}/**/*"].to_a
   s.require_path = "lib"
@@ -72,7 +38,6 @@ spec = Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.8.6'
   s.extra_rdoc_files = %w[README.rdoc LICENSE]
   s.add_dependency("rake", ">= #{RAKEVERSION}")
-  s.add_development_dependency("rubyforge", ">= #{::RubyForge::VERSION}")
 end
 
 desc "Run all examples"
@@ -103,44 +68,6 @@ task :clean => [ :clobber_rdoc, :clobber_package ] do
   %w[*.gem ri coverage*].each do |pattern|
     files = Dir[pattern]
     rm_rf files unless files.empty?
-  end
-end
-
-namespace :forge do
-  desc 'Publish RDoc to RubyForge'
-  task :publish_docs => [:clean, :rdoc] do
-    config = YAML.load(File.read(File.expand_path("~/.rubyforge/user-config.yml")))
-    host = "#{config["username"]}@rubyforge.org"
-    remote_dir = "/var/www/gforge-projects/#{spec.rubyforge_project}"
-    local_dir = 'doc'
-    sh %{rsync -av --delete #{local_dir}/ #{host}:#{remote_dir}}
-  end
-
-  desc 'Package and upload the release to rubyforge.'
-  task :release => [:clean, :package] do |t|
-    v = ENV["VERSION"] or abort "Must supply VERSION=x.y.z"
-    abort "Versions don't match '#{v}' vs '#{spec.version}'" if v != spec.version.to_s
-    pkg = "pkg/#{spec.name}-#{spec.version}"
-
-    if $DEBUG then
-      puts "release_id = rf.add_release #{spec.rubyforge_project.inspect}, #{spec.name.inspect}, #{version.inspect}, \"#{pkg}.tgz\""
-      puts "rf.add_file #{spec.rubyforge_project.inspect}, #{spec.name.inspect}, release_id, \"#{pkg}.gem\""
-    end
-
-    rf = RubyForge.new
-    puts "Logging in"
-    rf.login
-
-    changes = open("NOTES.md").readlines.join("") if File.exists?("NOTES.md")
-    c = rf.userconfig
-    c["release_notes"] = spec.description if spec.description
-    c["release_changes"] = changes if changes
-    c["preformatted"] = true
-
-    files = ["#{pkg}.tgz", "#{pkg}.gem"].compact
-
-    puts "Releasing #{spec.name} v. #{spec.version}"
-    rf.add_release spec.rubyforge_project, spec.name, spec.version.to_s, *files
   end
 end
 

--- a/ruby-hl7.gemspec
+++ b/ruby-hl7.gemspec
@@ -26,19 +26,13 @@ Gem::Specification.new do |s|
   s.rubyforge_project = %q{ruby-hl7}
   s.rubygems_version = %q{1.4.2}
   s.summary = %q{Ruby HL7 Library}
+  s.license = "MIT"
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
+  s.add_dependency 'rake', '~> 11.0'
+  s.add_dependency 'rdoc', '~> 3.9'
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rake>, [">= 10.0.0"])
-      s.add_development_dependency(%q<rubyforge>, [">= 2.0.4"])
-    else
-      s.add_dependency(%q<rake>, [">= 10.0.0"])
-      s.add_development_dependency(%q<rubyforge>, [">= 2.0.4"])
-    end
-  else
-    s.add_dependency(%q<rake>, [">= 10.0.0"])
-    s.add_development_dependency(%q<rubyforge>, [">= 2.0.4"])
-  end
+  s.add_development_dependency 'bundler', '~> 1.15'
+  s.add_development_dependency 'simplecov', '~> 0.15'
+  s.add_development_dependency 'rspec', '~> 2.99'
+  s.add_development_dependency 'pry'
 end

--- a/spec/ail_segment_spec.rb
+++ b/spec/ail_segment_spec.rb
@@ -8,21 +8,21 @@ describe HL7::Message::Segment::AIL do
     end
 
     it 'creates an AIL segment' do
-      lambda do
+      expect do
         ail = HL7::Message::Segment::AIL.new( @base_ail )
-        ail.should_not be_nil
-        ail.to_s.should eq @base_ail
-      end.should_not raise_error
+        expect(ail).not_to be_nil
+        expect(ail.to_s).to eq @base_ail
+      end.not_to raise_error
     end
 
     it 'allows access to an AIL segment' do
-      lambda do
+      expect do
         ail = HL7::Message::Segment::AIL.new( @base_ail )
-        ail.set_id.should eq '1'
-        ail.segment_action_code.should eq 'A'
-        ail.location_resource_id.should eq 'OFFICE^^^OFFICE'
-        ail.location_type.should eq '^OFFICE^A4'
-      end.should_not raise_error
+        expect(ail.set_id).to eq '1'
+        expect(ail.segment_action_code).to eq 'A'
+        expect(ail.location_resource_id).to eq 'OFFICE^^^OFFICE'
+        expect(ail.location_type).to eq '^OFFICE^A4'
+      end.not_to raise_error
     end
   end
 end

--- a/spec/aip_segment_spec.rb
+++ b/spec/aip_segment_spec.rb
@@ -8,24 +8,24 @@ describe HL7::Message::Segment::AIP do
     end
 
     it 'creates an AIP segment' do
-      lambda do
+      expect do
         aip = HL7::Message::Segment::AIP.new( @base_aip )
-        aip.should_not be_nil
-        aip.to_s.should eq @base_aip
-      end.should_not raise_error
+        expect(aip).not_to be_nil
+        expect(aip.to_s).to eq @base_aip
+      end.not_to raise_error
     end
 
     it 'allows access to an AIP segment' do
-      lambda do
+      expect do
         aip = HL7::Message::Segment::AIP.new( @base_aip )
-        aip.set_id.should eq '1'
-        aip.segment_action_code.should eq 'U'
-        aip.personnel_resource_id.should eq 'JSB^ISON^Kathy^S'
-        aip.resource_role.should eq 'D^Doctor'
-        aip.start_date_time.should eq '20020108150000'
-        aip.duration.should eq '10'
-        aip.duration_units.should eq 'm^Minutes'
-      end.should_not raise_error
+        expect(aip.set_id).to eq '1'
+        expect(aip.segment_action_code).to eq 'U'
+        expect(aip.personnel_resource_id).to eq 'JSB^ISON^Kathy^S'
+        expect(aip.resource_role).to eq 'D^Doctor'
+        expect(aip.start_date_time).to eq '20020108150000'
+        expect(aip.duration).to eq '10'
+        expect(aip.duration_units).to eq 'm^Minutes'
+      end.not_to raise_error
     end
   end
 end

--- a/spec/basic_parsing_spec.rb
+++ b/spec/basic_parsing_spec.rb
@@ -14,65 +14,65 @@ describe HL7::Message do
     it 'parses simple text' do
       msg = HL7::Message.new
       msg.parse @simple_msh_txt
-      msg.to_hl7.should eq @simple_msh_txt
+      expect(msg.to_hl7).to eq @simple_msh_txt
     end
 
     it 'parses delimiters properly' do
       msg = HL7::Message.new( @base_msh )
-      msg.element_delim.should eq "|"
-      msg.item_delim.should eq "^"
+      expect(msg.element_delim).to eq "|"
+      expect(msg.item_delim).to eq "^"
 
       msg = HL7::Message.new( @base_msh_alt_delims )
-      msg.element_delim.should eq "$"
-      msg.item_delim.should eq "@"
+      expect(msg.element_delim).to eq "$"
+      expect(msg.item_delim).to eq "@"
     end
 
     it 'parses via the constructor' do
       msg = HL7::Message.new( @simple_msh_txt )
-      msg.to_hl7.should eq @simple_msh_txt
+      expect(msg.to_hl7).to eq @simple_msh_txt
     end
 
     it 'parses via the class method' do
       msg = HL7::Message.parse( @simple_msh_txt )
-      msg.to_hl7.should eq @simple_msh_txt
+      expect(msg.to_hl7).to eq @simple_msh_txt
     end
 
     it 'only parses String and Enumerable data' do
-      lambda { HL7::Message.parse :MSHthis_shouldnt_parse_at_all }.should raise_error(HL7::ParseError)
+      expect { HL7::Message.parse :MSHthis_shouldnt_parse_at_all }.to raise_error(HL7::ParseError)
     end
 
     it 'parses empty strings' do
-      lambda { HL7::Message.new @empty_txt }.should_not raise_error
+      expect { HL7::Message.new @empty_txt }.not_to raise_error
     end
 
     it 'converts to strings' do
       msg = HL7::Message.new
       msg.parse @simple_msh_txt
       orig = @simple_msh_txt.gsub( /\r/, "\n" )
-      msg.to_s.should eq orig
+      expect(msg.to_s).to eq orig
     end
 
     it 'converts to a string and to HL7' do
       msg = HL7::Message.new( @simple_msh_txt )
-      msg.to_hl7.should_not == msg.to_s
+      expect(msg.to_hl7).not_to eq(msg.to_s)
     end
 
     it 'allows access to segments by index' do
       msg = HL7::Message.new
       msg.parse @simple_msh_txt
-      msg[0].to_s.should eq @base_msh
+      expect(msg[0].to_s).to eq @base_msh
     end
 
     it 'allows access to segments by name' do
       msg = HL7::Message.new
       msg.parse @simple_msh_txt
-      msg["MSH"].to_s.should eq @base_msh
+      expect(msg["MSH"].to_s).to eq @base_msh
     end
 
     it 'allows access to segments by symbol' do
       msg = HL7::Message.new
       msg.parse @simple_msh_txt
-      msg[:MSH].to_s.should eq @base_msh
+      expect(msg[:MSH].to_s).to eq @base_msh
     end
 
     it 'inserts segments by index' do
@@ -80,15 +80,15 @@ describe HL7::Message do
       msg.parse @simple_msh_txt
       inp = HL7::Message::Segment::Default.new
       msg[1] = inp
-      msg[1].should eq inp
+      expect(msg[1]).to eq inp
 
-      lambda { msg[2] = Class.new }.should raise_error(HL7::Exception)
+      expect { msg[2] = Class.new }.to raise_error(HL7::Exception)
     end
 
     it 'returns nil when accessing a missing segment' do
       msg = HL7::Message.new
       msg.parse @simple_msh_txt
-      lambda { msg[:does_not_exist].should be_nil }.should_not raise_error
+      expect { expect(msg[:does_not_exist]).to be_nil }.not_to raise_error
     end
 
     it 'inserts segments by name' do
@@ -96,8 +96,8 @@ describe HL7::Message do
       msg.parse @simple_msh_txt
       inp = HL7::Message::Segment::NTE.new
       msg["NTE"] = inp
-      msg["NTE"].should eq inp
-      lambda { msg["NTE"] = Class.new }.should raise_error(HL7::Exception)
+      expect(msg["NTE"]).to eq inp
+      expect { msg["NTE"] = Class.new }.to raise_error(HL7::Exception)
     end
 
     it 'inserts segments by symbol' do
@@ -105,67 +105,67 @@ describe HL7::Message do
       msg.parse @simple_msh_txt
       inp = HL7::Message::Segment::NTE.new
       msg[:NTE] = inp
-      msg[:NTE].should eq inp
-      lambda { msg[:NTE] = Class.new }.should raise_error(HL7::Exception)
+      expect(msg[:NTE]).to eq inp
+      expect { msg[:NTE] = Class.new }.to raise_error(HL7::Exception)
     end
 
     it 'allows access to segment elements' do
       msg = HL7::Message.new
       msg.parse @simple_msh_txt
-      msg[:MSH].sending_app.should eq "LAB1"
+      expect(msg[:MSH].sending_app).to eq "LAB1"
     end
 
     it 'allows modification of segment elements' do
       msg = HL7::Message.new
       msg.parse @simple_msh_txt
       msg[:MSH].sending_app = "TEST"
-      msg[:MSH].sending_app.should eq "TEST"
+      expect(msg[:MSH].sending_app).to eq "TEST"
     end
 
     it 'raises NoMethodError when accessing a missing element' do
       msg = HL7::Message.new
       msg.parse @simple_msh_txt
-      lambda {msg[:MSH].does_not_really_exist_here}.should raise_error(NoMethodError)
+      expect {msg[:MSH].does_not_really_exist_here}.to raise_error(NoMethodError)
     end
 
     it 'raises NoMethodError when modifying a missing element' do
       msg = HL7::Message.new
       msg.parse @simple_msh_txt
-      lambda {msg[:MSH].does_not_really_exist_here="TEST"}.should raise_error(NoMethodError)
+      expect {msg[:MSH].does_not_really_exist_here="TEST"}.to raise_error(NoMethodError)
     end
 
     it 'permits elements to be accessed via numeric names' do
       msg = HL7::Message.new( @simple_msh_txt )
-      msg[:MSH].e2.should eq "LAB1"
-      msg[:MSH].e3.should be_empty
+      expect(msg[:MSH].e2).to eq "LAB1"
+      expect(msg[:MSH].e3).to be_empty
     end
 
     it 'permits elements to be modified via numeric names' do
       msg = HL7::Message.parse( @simple_msh_txt )
       msg[:MSH].e2 = "TESTING1234"
-      msg[:MSH].e2.should eq "TESTING1234"
+      expect(msg[:MSH].e2).to eq "TESTING1234"
     end
 
     it 'allows appending of segments' do
       msg = HL7::Message.new
-      lambda do
+      expect do
         msg << HL7::Message::Segment::MSH.new
         msg << HL7::Message::Segment::NTE.new
-      end.should_not raise_error
+      end.not_to raise_error
 
-      lambda { msg << Class.new }.should raise_error(HL7::Exception)
+      expect { msg << Class.new }.to raise_error(HL7::Exception)
     end
 
     it 'allows appending of an array of segments' do
       msg = HL7::Message.new
-      lambda do
+      expect do
         msg << [HL7::Message::Segment::MSH.new, HL7::Message::Segment::NTE.new]
-      end.should_not raise_error
+      end.not_to raise_error
 
       obx = HL7::Message::Segment::OBX.new
-      lambda do
+      expect do
         obx.children << [HL7::Message::Segment::NTE.new, HL7::Message::Segment::NTE.new]
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
     it 'sorts segments' do
@@ -183,7 +183,7 @@ describe HL7::Message do
       initial = msg.to_s
       sorted = msg.sort
       final = sorted.to_s
-      initial.should_not == final
+      expect(initial).not_to eq(final)
     end
 
     it 'automatically assigns a set_id to a new segment' do
@@ -199,76 +199,76 @@ describe HL7::Message do
       ntec = HL7::Message::Segment::NTE.new
       ntec.comment = "third"
       msg << ntec
-      ntea.set_id.should eq "1"
-      nteb.set_id.should eq "2"
-      ntec.set_id.should eq "3"
+      expect(ntea.set_id).to eq "1"
+      expect(nteb.set_id).to eq "2"
+      expect(ntec.set_id).to eq "3"
     end
 
     it 'parses Enumerable data' do
       test_file = open( './test_data/test.hl7' )
-      test_file.should_not be_nil
+      expect(test_file).not_to be_nil
 
       msg = HL7::Message.new( test_file )
-      msg.to_hl7.should eq @simple_msh_txt
+      expect(msg.to_hl7).to eq @simple_msh_txt
     end
 
     it 'has a to_info method' do
       msg = HL7::Message.new( @simple_msh_txt )
-      msg[1].to_info.should_not be_nil
+      expect(msg[1].to_info).not_to be_nil
     end
 
     it 'parses a raw array' do
       inp = "NTE|1|ME TOO"
       nte = HL7::Message::Segment::NTE.new( inp.split( '|' ) )
-      nte.to_s.should eq inp
+      expect(nte.to_s).to eq inp
     end
 
     it 'produces MLLP output' do
       msg = HL7::Message.new( @simple_msh_txt )
       expect = "\x0b%s\x1c\r" % msg.to_hl7
-      msg.to_mllp.should eq expect
+      expect(msg.to_mllp).to eq expect
     end
 
     it 'parses MLLP input' do
       raw = "\x0b%s\x1c\r" % @simple_msh_txt
       msg = HL7::Message.parse( raw )
-      msg.should_not be_nil
-      msg.to_hl7.should eq @simple_msh_txt
-      msg.to_mllp.should eq raw
+      expect(msg).not_to be_nil
+      expect(msg.to_hl7).to eq @simple_msh_txt
+      expect(msg.to_mllp).to eq raw
     end
 
     it 'can parse its own MLLP output' do
       msg = HL7::Message.parse( @simple_msh_txt )
-      msg.should_not be_nil
-      lambda do
+      expect(msg).not_to be_nil
+      expect do
         post_mllp = HL7::Message.parse( msg.to_mllp )
-        post_mllp.should_not be_nil
-        msg.to_hl7.should eq post_mllp.to_hl7
-      end.should_not raise_error
+        expect(post_mllp).not_to be_nil
+        expect(msg.to_hl7).to eq post_mllp.to_hl7
+      end.not_to raise_error
     end
 
     it 'can access child elements' do
       obr = HL7::Message::Segment::OBR.new
-      lambda do
-        obr.children.should_not be_nil
-        obr.children.length.should be_zero
-      end.should_not raise_error
+      expect do
+        expect(obr.children).not_to be_nil
+        expect(obr.children.length).to be_zero
+      end.not_to raise_error
     end
 
     it 'can add child elements' do
       obr = HL7::Message::Segment::OBR.new
-      lambda do
-        obr.children.length.should be_zero
+      expect do
+        expect(obr.children.length).to be_zero
         (1..5).each do |x|
           obr.children << HL7::Message::Segment::OBX.new
-          obr.children.length.should eq x
+          expect(obr.children.length).to eq x
         end
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
     it 'rejects invalid child segments' do
       obr = HL7::Message::Segment::OBR.new
-      lambda { obr.children << Class.new }.should raise_error(HL7::Exception)
+      expect { obr.children << Class.new }.to raise_error(HL7::Exception)
     end
 
     it 'supports grouped, sequenced segments' do
@@ -284,36 +284,36 @@ describe HL7::Message do
         end
       end
 
-      msg[:OBR].should_not be_nil
-      msg[:OBR].length.should eq 11
-      msg[:OBX].should_not be_nil
-      msg[:OBX].length.should eq 102
-      msg[:OBR][4].children[1].set_id.should eq "2"
-      msg[:OBR][5].children[1].set_id.should eq "2"
+      expect(msg[:OBR]).not_to be_nil
+      expect(msg[:OBR].length).to eq 11
+      expect(msg[:OBX]).not_to be_nil
+      expect(msg[:OBX].length).to eq 102
+      expect(msg[:OBR][4].children[1].set_id).to eq "2"
+      expect(msg[:OBR][5].children[1].set_id).to eq "2"
 
       final_output = msg.to_hl7
-      orig_output.should_not == final_output
+      expect(orig_output).not_to eq(final_output)
     end
 
     it "returns each segment's index" do
       msg = HL7::Message.parse( @simple_msh_txt )
-      msg.index("PID").should eq 1
-      msg.index(:PID).should eq 1
-      msg.index("PV1").should eq 2
-      msg.index(:PV1).should eq 2
-      msg.index("TACOBELL").should be_nil
-      msg.index(nil).should be_nil
-      msg.index(1).should be_nil
+      expect(msg.index("PID")).to eq 1
+      expect(msg.index(:PID)).to eq 1
+      expect(msg.index("PV1")).to eq 2
+      expect(msg.index(:PV1)).to eq 2
+      expect(msg.index("TACOBELL")).to be_nil
+      expect(msg.index(nil)).to be_nil
+      expect(msg.index(1)).to be_nil
     end
 
     it 'validates the PID#admin_sex element' do
       pid = HL7::Message::Segment::PID.new
-      lambda { pid.admin_sex = "TEST" }.should raise_error(HL7::InvalidDataError)
-      lambda { pid.admin_sex = "F" }.should_not raise_error
+      expect { pid.admin_sex = "TEST" }.to raise_error(HL7::InvalidDataError)
+      expect { pid.admin_sex = "F" }.not_to raise_error
     end
 
     it 'can parse an empty segment' do
-      lambda { HL7::Message.new @empty_segments_txt }.should_not raise_error
+      expect { HL7::Message.new @empty_segments_txt }.not_to raise_error
     end
   end
 end

--- a/spec/batch_parsing_spec.rb
+++ b/spec/batch_parsing_spec.rb
@@ -4,21 +4,21 @@ require 'spec_helper'
 describe HL7::Message do
   context 'batch parsing' do
     it 'should have a class method HL7::Message.parse_batch' do
-      HL7::Message.should respond_to(:parse_batch)
+      expect(HL7::Message).to respond_to(:parse_batch)
     end
 
     it 'should raise an exception when parsing an empty batch' do
       # :empty_batch message contains a valid batch envelope with no
       # contents
-      lambda do
+      expect do
         HL7::Message.parse_batch HL7MESSAGES[:empty_batch]
-      end.should raise_exception(HL7::ParseError, 'empty_batch_message')
+      end.to raise_exception(HL7::ParseError, 'empty_batch_message')
     end
 
     it 'should raise an exception when parsing a single message as a batch' do
-      lambda do
+      expect do
         HL7::Message.parse_batch HL7MESSAGES[:realm_minimal_message]
-      end.should raise_exception(HL7::ParseError, 'badly_formed_batch_message')
+      end.to raise_exception(HL7::ParseError, 'badly_formed_batch_message')
     end
 
     it 'should yield multiple messages from a valid batch' do
@@ -26,7 +26,7 @@ describe HL7::Message do
       HL7::Message.parse_batch(HL7MESSAGES[:realm_batch]) do |m|
         count += 1
       end
-      count.should eq 2
+      expect(count).to eq 2
     end
   end
 end
@@ -38,15 +38,15 @@ describe 'String extension' do
   end
 
   it 'should respond_to :hl7_batch?' do
-    @batch_message.hl7_batch?.should be true
-    @plain_message.should respond_to(:hl7_batch?)
+    expect(@batch_message.hl7_batch?).to be true
+    expect(@plain_message).to respond_to(:hl7_batch?)
   end
 
   it 'should return true when passed a batch message' do
-    @batch_message.should be_an_hl7_batch
+    expect(@batch_message).to be_an_hl7_batch
   end
 
   it 'should return false when passed a plain message' do
-    @plain_message.should_not be_an_hl7_batch
+    expect(@plain_message).not_to be_an_hl7_batch
   end
 end

--- a/spec/child_segment_spec.rb
+++ b/spec/child_segment_spec.rb
@@ -9,57 +9,57 @@ describe HL7::Message do
 
     it 'allows access to child segments' do
       msg = HL7::Message.new @base
-      msg.should_not be_nil
-      msg[:OBR].should_not be_nil
-      msg[:OBR].length.should eq 3
-      msg[:OBR][0].children.should_not be_nil
-      msg[:OBR][0].children.length.should eq 6
-      msg[:OBR][1].children.should_not be_nil
-      msg[:OBR][1].children.length.should eq 3
-      msg[:OBR][2].children.should_not be_nil
-      msg[:OBR][2].children.length.should eq 1
-      msg[:OBX][0].children.should_not be_nil
-      msg[:OBX][0].children.length.should eq 1
+      expect(msg).not_to be_nil
+      expect(msg[:OBR]).not_to be_nil
+      expect(msg[:OBR].length).to eq 3
+      expect(msg[:OBR][0].children).not_to be_nil
+      expect(msg[:OBR][0].children.length).to eq 6
+      expect(msg[:OBR][1].children).not_to be_nil
+      expect(msg[:OBR][1].children.length).to eq 3
+      expect(msg[:OBR][2].children).not_to be_nil
+      expect(msg[:OBR][2].children.length).to eq 1
+      expect(msg[:OBX][0].children).not_to be_nil
+      expect(msg[:OBX][0].children.length).to eq 1
 
       msg[:OBR][0].children.each do |x|
-        x.should_not be_nil
+        expect(x).not_to be_nil
       end
       msg[:OBR][1].children.each do |x|
-        x.should_not be_nil
+        expect(x).not_to be_nil
       end
       msg[:OBR][2].children.each do |x|
-        x.should_not be_nil
+        expect(x).not_to be_nil
       end
     end
 
     it 'allows adding child segments' do
       msg = HL7::Message.new @base
-      msg.should_not be_nil
-      msg[:OBR].should_not be_nil
+      expect(msg).not_to be_nil
+      expect(msg[:OBR]).not_to be_nil
       ob = HL7::Message::Segment::OBR.new
-      ob.should_not be_nil
+      expect(ob).not_to be_nil
 
       msg << ob
-      ob.children.should_not be_nil
-      ob.segment_parent.should_not be_nil
-      ob.segment_parent.should eq msg
+      expect(ob.children).not_to be_nil
+      expect(ob.segment_parent).not_to be_nil
+      expect(ob.segment_parent).to eq msg
       orig_cnt = msg.length
 
       (1..4).each do |x|
         m = HL7::Message::Segment::OBX.new
         m.observation_value = "taco"
-        m.should_not be_nil
-        /taco/.match(m.to_s).should_not be_nil
+        expect(m).not_to be_nil
+        expect(/taco/.match(m.to_s)).not_to be_nil
         ob.children << m
-        ob.children.length.should eq x
-        m.segment_parent.should_not be_nil
-        m.segment_parent.should eq ob
+        expect(ob.children.length).to eq x
+        expect(m.segment_parent).not_to be_nil
+        expect(m.segment_parent).to eq ob
       end
 
-      @base.should_not eq msg.to_hl7
-      msg.length.should_not eq orig_cnt
+      expect(@base).not_to eq msg.to_hl7
+      expect(msg.length).not_to eq orig_cnt
       text_ver = msg.to_hl7
-      /taco/.match(text_ver).should_not be_nil
+      expect(/taco/.match(text_ver)).not_to be_nil
     end
   end
 end

--- a/spec/core_ext/date_time_spec.rb
+++ b/spec/core_ext/date_time_spec.rb
@@ -5,7 +5,7 @@ describe Date do
   subject{ Date.parse('2013-12-02').to_hl7 }
 
   it "should respond to the HL7 timestamp" do
-    subject.should eq "20131202"
+    expect(subject).to eq "20131202"
   end
 end
 
@@ -17,13 +17,13 @@ describe "to_hl7 for time related classes" do
 
   shared_examples "a time to_hl7" do
     context "without fraction" do
-      it { time_now.to_time.to_hl7.should eq formated_time }
+      it { expect(time_now.to_time.to_hl7).to eq formated_time }
     end
 
     context "with_fraction" do
-      it { time_now.to_time.to_hl7(3).should eq formated_time + fraction_3 }
+      it { expect(time_now.to_time.to_hl7(3)).to eq formated_time + fraction_3 }
 
-      it { time_now.to_time.to_hl7(9).should eq formated_time + fraction_9 }
+      it { expect(time_now.to_time.to_hl7(9)).to eq formated_time + fraction_9 }
     end
   end
 

--- a/spec/default_segment_spec.rb
+++ b/spec/default_segment_spec.rb
@@ -10,13 +10,13 @@ describe HL7::Message::Segment::Default do
 
     it 'stores an existing segment' do
       seg = HL7::Message::Segment::Default.new( @base_msa )
-      seg.to_s.should eq @base_msa
+      expect(seg.to_s).to eq @base_msa
     end
 
     it 'converts to a string' do
       seg = HL7::Message::Segment::Default.new( @base_msa )
-      seg.to_s.should eq @base_msa
-      seg.to_hl7.should eq seg.to_s
+      expect(seg.to_s).to eq @base_msa
+      expect(seg.to_hl7).to eq seg.to_s
     end
 
     it 'creates a raw segment' do
@@ -25,7 +25,7 @@ describe HL7::Message::Segment::Default do
       seg.e1 = "INFO"
       seg.e2 = "MORE INFO"
       seg.e5 = "LAST INFO"
-      seg.to_s.should eq "NK1|INFO|MORE INFO|||LAST INFO"
+      expect(seg.to_s).to eq "NK1|INFO|MORE INFO|||LAST INFO"
     end
   end
 end

--- a/spec/dynamic_segment_def_spec.rb
+++ b/spec/dynamic_segment_def_spec.rb
@@ -10,7 +10,7 @@ describe 'dynamic segment definition' do
         s.e2 = "5678"
       end
 
-      seg.to_s.should eq "MSK|1234|5678"
+      expect(seg.to_s).to eq "MSK|1234|5678"
     end
 
     it 'accepts a block without a parameter' do
@@ -20,7 +20,7 @@ describe 'dynamic segment definition' do
         e2 "5678"
       end
 
-      seg.to_s.should eq "MSK|1234|5678"
+      expect(seg.to_s).to eq "MSK|1234|5678"
     end
 
     it "doesn't pollute the caller namespace" do
@@ -30,8 +30,8 @@ describe 'dynamic segment definition' do
         s.e2 = "5678"
       end
 
-      lambda { e3 "TEST" }.should raise_error(NoMethodError)
-      seg.to_s.should eq "MSK|1234|5678"
+      expect { e3 "TEST" }.to raise_error(NoMethodError)
+      expect(seg.to_s).to eq "MSK|1234|5678"
     end
   end
 end

--- a/spec/err_segment_spec.rb
+++ b/spec/err_segment_spec.rb
@@ -8,19 +8,19 @@ describe HL7::Message::Segment::ERR do
     end
 
     it 'creates an ERR segment' do
-      lambda do
+      expect do
         err = HL7::Message::Segment::ERR.new( @base_err )
-        err.should_not be_nil
-        err.to_s.should eq @base_err
-      end.should_not raise_error
+        expect(err).not_to be_nil
+        expect(err.to_s).to eq @base_err
+      end.not_to raise_error
     end
 
     it 'allows access to an ERR segment' do
-      lambda do
+      expect do
         err = HL7::Message::Segment::ERR.new( @base_err )
-        err.severity.should eq 'E'
-        err.error_location.should eq 'OBR^1'
-      end.should_not raise_error
+        expect(err.severity).to eq 'E'
+        expect(err.error_location).to eq 'OBR^1'
+      end.not_to raise_error
     end
   end
 end

--- a/spec/evn_segment_spec.rb
+++ b/spec/evn_segment_spec.rb
@@ -9,15 +9,15 @@ describe HL7::Message::Segment::EVN do
 
     it 'allows access to an EVN segment' do
       evn = HL7::Message::Segment::EVN.new @base
-      evn.type_code.should eq "A04"
+      expect(evn.type_code).to eq "A04"
     end
 
     it 'allows creation of an EVN segment' do
       evn = HL7::Message::Segment::EVN.new
       evn.event_facility="A Facility"
-      evn.event_facility.should eq 'A Facility'
+      expect(evn.event_facility).to eq 'A Facility'
       evn.recorded_date = Date.new 2001,2,3
-      evn.recorded_date.should eq "20010203"
+      expect(evn.recorded_date).to eq "20010203"
     end
   end
 end

--- a/spec/in1_segment_spec.rb
+++ b/spec/in1_segment_spec.rb
@@ -8,27 +8,27 @@ describe HL7::Message::Segment::IN1 do
     end
 
     it 'creates an IN1 segment' do
-      lambda do
+      expect do
         in1 = HL7::Message::Segment::IN1.new( @base_in1 )
-        in1.should_not be_nil
-        in1.to_s.should eq @base_in1
-      end.should_not raise_error
+        expect(in1).not_to be_nil
+        expect(in1.to_s).to eq @base_in1
+      end.not_to raise_error
     end
 
     it 'allows access to an IN1 segment' do
-      lambda do
+      expect do
         in1 = HL7::Message::Segment::IN1.new( @base_in1 )
-        in1.set_id.should eq '1'
-        in1.insurance_company_id.should eq '752'
-        in1.insurance_company_name.should eq 'ACORDIA NATIONAL'
-        in1.group_number.should eq 'A'
-        in1.group_name.should eq 'GRP'
-        in1.name_of_insured.should eq 'SMITH^JOHN'
-        in1.insureds_relationship_to_patient.should eq '19'
-        in1.insureds_date_of_birth.should eq '19700102'
-        in1.policy_number.should eq 'WC23732763278A'
-        in1.vip_indicator.should eq 'X'
-      end.should_not raise_error
+        expect(in1.set_id).to eq '1'
+        expect(in1.insurance_company_id).to eq '752'
+        expect(in1.insurance_company_name).to eq 'ACORDIA NATIONAL'
+        expect(in1.group_number).to eq 'A'
+        expect(in1.group_name).to eq 'GRP'
+        expect(in1.name_of_insured).to eq 'SMITH^JOHN'
+        expect(in1.insureds_relationship_to_patient).to eq '19'
+        expect(in1.insureds_date_of_birth).to eq '19700102'
+        expect(in1.policy_number).to eq 'WC23732763278A'
+        expect(in1.vip_indicator).to eq 'X'
+      end.not_to raise_error
     end
   end
 end

--- a/spec/messages_spec.rb
+++ b/spec/messages_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe "HL7 Messages" do
   it 'processes multiple known messages without failing' do
-    lambda do
+    expect do
       HL7MESSAGES.each_pair do |key, hl7|
         HL7::Message.new(hl7)
       end
-    end.should_not raise_exception
+    end.not_to raise_exception
   end
 
   describe 'MFN M13 Messages' do

--- a/spec/mfe_segment_spec.rb
+++ b/spec/mfe_segment_spec.rb
@@ -8,21 +8,21 @@ describe HL7::Message::Segment::MFE do
     end
 
     it 'creates an MFE segment' do
-      lambda do
+      expect do
         sft = HL7::Message::Segment::MFE.new( @base_sft )
-        sft.should_not be_nil
-        sft.to_s.should == @base_sft
-      end.should_not raise_error
+        expect(sft).not_to be_nil
+        expect(sft.to_s).to eq(@base_sft)
+      end.not_to raise_error
     end
 
     it 'allows access to an MFE segment' do
-      lambda do
+      expect do
         sft = HL7::Message::Segment::MFE.new( @base_sft )
-        sft.record_level_event_code.should eq 'MAD'
-        sft.mfn_control_id.should eq '6772331'
-        sft.primary_key_value.should eq 'BUD^Buddhist^HL70006'
-        sft.primary_key_value_type.should eq 'CE'
-      end.should_not raise_error
+        expect(sft.record_level_event_code).to eq 'MAD'
+        expect(sft.mfn_control_id).to eq '6772331'
+        expect(sft.primary_key_value).to eq 'BUD^Buddhist^HL70006'
+        expect(sft.primary_key_value_type).to eq 'CE'
+      end.not_to raise_error
     end
   end
 end

--- a/spec/mfi_segment_spec.rb
+++ b/spec/mfi_segment_spec.rb
@@ -8,21 +8,21 @@ describe HL7::Message::Segment::MFI do
     end
 
     it 'creates an MFI segment' do
-      lambda do
+      expect do
         sft = described_class.new( @base_sft )
-        sft.should_not be_nil
-        sft.to_s.should == @base_sft
-      end.should_not raise_error
+        expect(sft).not_to be_nil
+        expect(sft.to_s).to eq(@base_sft)
+      end.not_to raise_error
     end
 
     it 'allows access to an MFI segment' do
-      lambda do
+      expect do
         sft = described_class.new( @base_sft )
-        sft.master_file_identifier.should eq 'HL70006^RELIGION^HL70175'
-        sft.master_file_application_identifier.should eq 'TEST'
-        sft.file_level_event_code.should eq 'UPD'
-        sft.response_level_code.should eq 'AL'
-      end.should_not raise_error
+        expect(sft.master_file_identifier).to eq 'HL70006^RELIGION^HL70175'
+        expect(sft.master_file_application_identifier).to eq 'TEST'
+        expect(sft.file_level_event_code).to eq 'UPD'
+        expect(sft.response_level_code).to eq 'AL'
+      end.not_to raise_error
     end
   end
 end

--- a/spec/msa_segment_spec.rb
+++ b/spec/msa_segment_spec.rb
@@ -9,19 +9,19 @@ describe HL7::Message::Segment::MSA do
     end
 
     it 'creates an MSA segment' do
-      lambda do
+      expect do
         msa = HL7::Message::Segment::MSA.new( @base_msa )
-        msa.should_not be_nil
-        msa.to_s.should eq @base_msa
-      end.should_not raise_error
+        expect(msa).not_to be_nil
+        expect(msa.to_s).to eq @base_msa
+      end.not_to raise_error
     end
 
     it 'allows access to an MSA segment' do
-      lambda do
+      expect do
         msa = HL7::Message::Segment::MSA.new( @base_msa )
-        msa.ack_code.should eq "AR"
-        msa.control_id.should eq "ZZ9380 ERR"
-      end.should_not raise_error
+        expect(msa.ack_code).to eq "AR"
+        expect(msa.control_id).to eq "ZZ9380 ERR"
+      end.not_to raise_error
     end
   end
 end

--- a/spec/msh_segment_spec.rb
+++ b/spec/msh_segment_spec.rb
@@ -10,19 +10,19 @@ describe HL7::Message::Segment::MSH do
     it 'allows access to an MSH segment' do
       msh = HL7::Message::Segment::MSH.new @base
       msh.enc_chars='^~\\&'
-      msh.version_id.should eq '2.5'
-      msh.country_code.should eq 'AU'
-      msh.charset.should eq 'ASCII'
-      msh.sending_responsible_org.should eq 'AN ORG'
-      msh.receiving_network_address.should eq 'RECNET.ORG'
+      expect(msh.version_id).to eq '2.5'
+      expect(msh.country_code).to eq 'AU'
+      expect(msh.charset).to eq 'ASCII'
+      expect(msh.sending_responsible_org).to eq 'AN ORG'
+      expect(msh.receiving_network_address).to eq 'RECNET.ORG'
     end
 
     it 'allows creation of an MSH segment' do
       msh = HL7::Message::Segment::MSH.new
       msh.sending_facility="A Facility"
-      msh.sending_facility.should eq 'A Facility'
+      expect(msh.sending_facility).to eq 'A Facility'
       msh.time = DateTime.iso8601('20010203T040506')
-      msh.time.should eq '20010203040506'
+      expect(msh.time).to eq '20010203040506'
     end
   end
 end

--- a/spec/nk1_segment_spec.rb
+++ b/spec/nk1_segment_spec.rb
@@ -8,19 +8,19 @@ describe HL7::Message::Segment::NK1 do
     end
 
     it 'creates an NK1 segment' do
-      lambda do
+      expect do
         nk1 = HL7::Message::Segment::NK1.new( @base_nk1 )
-        nk1.should_not be_nil
-        nk1.to_s.should eq @base_nk1
-      end.should_not raise_error
+        expect(nk1).not_to be_nil
+        expect(nk1.to_s).to eq @base_nk1
+      end.not_to raise_error
     end
 
     it 'allows access to an NK1 segment' do
-      lambda do
+      expect do
         nk1 = HL7::Message::Segment::NK1.new( @base_nk1 )
-        nk1.name.should eq 'Mum^Martha^M^^^^L'
-        nk1.phone_number.should eq '^PRN^PH^^1^555^5552006'
-      end.should_not raise_error
+        expect(nk1.name).to eq 'Mum^Martha^M^^^^L'
+        expect(nk1.phone_number).to eq '^PRN^PH^^1^555^5552006'
+      end.not_to raise_error
     end
   end
 end

--- a/spec/obr_segment_spec.rb
+++ b/spec/obr_segment_spec.rb
@@ -9,37 +9,37 @@ describe HL7::Message::Segment::OBR do
     end
 
     it 'allows access to an OBR segment' do
-      @obr.to_s.should eq @base
-      @obr.e1.should eq "2"
-      @obr.set_id.should eq "2"
-      @obr.placer_order_number.should eq "^USSSA"
-      @obr.filler_order_number.should eq "0000000567^USSSA"
-      @obr.universal_service_id.should eq "37956^CT ABDOMEN^LN"
+      expect(@obr.to_s).to eq @base
+      expect(@obr.e1).to eq "2"
+      expect(@obr.set_id).to eq "2"
+      expect(@obr.placer_order_number).to eq "^USSSA"
+      expect(@obr.filler_order_number).to eq "0000000567^USSSA"
+      expect(@obr.universal_service_id).to eq "37956^CT ABDOMEN^LN"
     end
 
     it 'allows modification of an OBR segment' do
       @obr.set_id = 1
-      @obr.set_id.should eq "1"
+      expect(@obr.set_id).to eq "1"
       @obr.placer_order_number = "^DMCRES"
-      @obr.placer_order_number.should eq "^DMCRES"
+      expect(@obr.placer_order_number).to eq "^DMCRES"
     end
 
     it 'supports the diagnostic_serv_sect_id method' do
-      @obr.should respond_to(:diagnostic_serv_sect_id)
-      @obr.diagnostic_serv_sect_id.should eq "NMR"
+      expect(@obr).to respond_to(:diagnostic_serv_sect_id)
+      expect(@obr.diagnostic_serv_sect_id).to eq "NMR"
     end
 
     it 'supports the result_status method' do
-      @obr.should respond_to(:result_status)
-      @obr.result_status.should eq "P"
+      expect(@obr).to respond_to(:result_status)
+      expect(@obr.result_status).to eq "P"
     end
 
     it 'supports the reason_for_study method' do
-      @obr.reason_for_study.should eq "R/O TUMOR"
+      expect(@obr.reason_for_study).to eq "R/O TUMOR"
     end
 
     it 'supports the parent_universal_service_identifier method' do
-      @obr.parent_universal_service_identifier.should eq "123"
+      expect(@obr.parent_universal_service_identifier).to eq "123"
     end
   end
 end

--- a/spec/obx_segment_spec.rb
+++ b/spec/obx_segment_spec.rb
@@ -9,39 +9,39 @@ describe HL7::Message::Segment::OBX do
 
     it 'allows access to an OBX segment' do
       obx = HL7::Message::Segment::OBX.new @base
-      obx.set_id.should eq "1"
-      obx.value_type.should eq "NM"
-      obx.observation_id.should eq "30341-2^Erythrocyte sedimentation rate^LN^815117^ESR^99USI^^^Erythrocyte sedimentation rate"
-      obx.observation_sub_id.should eq ""
-      obx.observation_value.should eq "10"
-      obx.units.should eq "mm/h^millimeter per hour^UCUM"
-      obx.references_range.should eq "0 to 17"
-      obx.abnormal_flags.should eq "N"
-      obx.probability.should eq "0.1"
-      obx.nature_of_abnormal_test.should eq ""
-      obx.observation_result_status.should eq "F"
-      obx.effective_date_of_reference_range.should eq ""
-      obx.user_defined_access_checks.should eq ""
-      obx.observation_date.should eq "20110331140551-0800"
-      obx.producer_id.should eq ""
-      obx.responsible_observer.should eq "Observer"
-      obx.observation_site.should eq '^A Site'
-      obx.observation_method.should eq ""
-      obx.equipment_instance_id.should eq ""
-      obx.analysis_date.should eq "20110331150551-0800"
-      obx.performing_organization_name.should eq "Century Hospital^^^^^NIST-AA-1&2.16.840.1.113883.3.72.5.30.1&ISO^XX^^^987"
-      obx.performing_organization_address.should eq "2070 Test Park^^Los Angeles^CA^90067^USA^B^^06037"
-      obx.performing_organization_medical_director.should eq "2343242^Knowsalot^Phil^J.^III^Dr.^^^NIST-AA-1&2.16.840.1.113883.3.72.5.30.1&ISO^L^^^DN"
+      expect(obx.set_id).to eq "1"
+      expect(obx.value_type).to eq "NM"
+      expect(obx.observation_id).to eq "30341-2^Erythrocyte sedimentation rate^LN^815117^ESR^99USI^^^Erythrocyte sedimentation rate"
+      expect(obx.observation_sub_id).to eq ""
+      expect(obx.observation_value).to eq "10"
+      expect(obx.units).to eq "mm/h^millimeter per hour^UCUM"
+      expect(obx.references_range).to eq "0 to 17"
+      expect(obx.abnormal_flags).to eq "N"
+      expect(obx.probability).to eq "0.1"
+      expect(obx.nature_of_abnormal_test).to eq ""
+      expect(obx.observation_result_status).to eq "F"
+      expect(obx.effective_date_of_reference_range).to eq ""
+      expect(obx.user_defined_access_checks).to eq ""
+      expect(obx.observation_date).to eq "20110331140551-0800"
+      expect(obx.producer_id).to eq ""
+      expect(obx.responsible_observer).to eq "Observer"
+      expect(obx.observation_site).to eq '^A Site'
+      expect(obx.observation_method).to eq ""
+      expect(obx.equipment_instance_id).to eq ""
+      expect(obx.analysis_date).to eq "20110331150551-0800"
+      expect(obx.performing_organization_name).to eq "Century Hospital^^^^^NIST-AA-1&2.16.840.1.113883.3.72.5.30.1&ISO^XX^^^987"
+      expect(obx.performing_organization_address).to eq "2070 Test Park^^Los Angeles^CA^90067^USA^B^^06037"
+      expect(obx.performing_organization_medical_director).to eq "2343242^Knowsalot^Phil^J.^III^Dr.^^^NIST-AA-1&2.16.840.1.113883.3.72.5.30.1&ISO^L^^^DN"
     end
 
     it 'allows creation of an OBX segment' do
-      lambda do
+      expect do
         obx = HL7::Message::Segment::OBX.new
         obx.value_type = "TESTIES"
         obx.observation_id = "HR"
         obx.observation_sub_id = "2"
         obx.observation_value = "SOMETHING HAPPENned"
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
     describe "#correction?" do

--- a/spec/orc_segment_spec.rb
+++ b/spec/orc_segment_spec.rb
@@ -9,19 +9,19 @@ describe HL7::Message::Segment::ORC do
     end
 
     it 'creates an ORC segment' do
-      lambda do
+      expect do
         orc = HL7::Message::Segment::ORC.new( @base_orc )
-        orc.should_not be_nil
-        orc.to_s.should eq @base_orc
-      end.should_not raise_error
+        expect(orc).not_to be_nil
+        expect(orc.to_s).to eq @base_orc
+      end.not_to raise_error
     end
 
     it 'allows access to an ORC segment' do
       orc = HL7::Message::Segment::ORC.new( @base_orc )
-      orc.ordering_provider.should eq '1234^Admit^Alan^A^III^Dr^^^&2.16.840.1.113883.19.4.6^ISO^L^^^EI^&2.16.840.1.113883.19.4.6^ISO^^^^^^^^MD'
-      orc.call_back_phone_number.should eq '^WPN^PH^^1^555^5551005'
-      orc.ordering_facility_name.should eq 'Level Seven Healthcare, Inc.^L^^^^&2.16.840.1.113883.19.4.6^ISO^XX^^^1234'
-      orc.parent_universal_service_identifier.should eq '7844'
+      expect(orc.ordering_provider).to eq '1234^Admit^Alan^A^III^Dr^^^&2.16.840.1.113883.19.4.6^ISO^L^^^EI^&2.16.840.1.113883.19.4.6^ISO^^^^^^^^MD'
+      expect(orc.call_back_phone_number).to eq '^WPN^PH^^1^555^5551005'
+      expect(orc.ordering_facility_name).to eq 'Level Seven Healthcare, Inc.^L^^^^&2.16.840.1.113883.19.4.6^ISO^XX^^^1234'
+      expect(orc.parent_universal_service_identifier).to eq '7844'
     end
   end
 end

--- a/spec/pid_segment_spec.rb
+++ b/spec/pid_segment_spec.rb
@@ -9,62 +9,62 @@ describe HL7::Message::Segment::PID do
 
     it 'validates the admin_sex element' do
       pid = HL7::Message::Segment::PID.new
-      lambda do
+      expect do
         vals = %w[F M O U A N C] + [ nil ]
         vals.each do |x|
           pid.admin_sex = x
         end
         pid.admin_sex = ""
-      end.should_not raise_error
+      end.not_to raise_error
 
-      lambda do
+      expect do
         ["TEST", "A", 1, 2].each do |x|
           pid.admin_sex = x
         end
-      end.should raise_error(HL7::InvalidDataError)
+      end.to raise_error(HL7::InvalidDataError)
     end
 
     it "sets values correctly" do
       pid = HL7::Message::Segment::PID.new @base
-      pid.set_id.should eq "1"
-      pid.patient_id.should eq ""
-      pid.patient_id_list.should eq "333"
-      pid.alt_patient_id.should eq ""
-      pid.patient_name.should eq "LastName^FirstName^MiddleInitial^SR^NickName"
-      pid.mother_maiden_name.should eq ""
-      pid.patient_dob.should eq "19760228"
-      pid.admin_sex.should eq "F"
-      pid.patient_alias.should eq ""
-      pid.race.should eq "2106-3^White^HL70005^CAUC^Caucasian^L"
-      pid.address.should eq ""
-      pid.country_code.should eq ""
-      pid.phone_home.should eq ""
-      pid.phone_business.should eq ""
-      pid.primary_language.should eq ""
-      pid.marital_status.should eq ""
-      pid.religion.should eq ""
-      pid.account_number.should eq "555.55"
-      pid.social_security_num.should eq "012345678"
-      pid.driver_license_num.should eq ""
-      pid.mothers_id.should eq ""
-      pid.ethnic_group.should eq ""
-      pid.birthplace.should eq ""
-      pid.multi_birth.should eq ""
-      pid.birth_order.should eq ""
-      pid.citizenship.should eq ""
-      pid.vet_status.should eq ""
-      pid.nationality.should eq ""
-      pid.death_date.should eq "201011110924-0700"
-      pid.death_indicator.should eq "Y"
-      pid.id_unknown_indicator.should eq ""
-      pid.id_readability_code.should eq ""
-      pid.last_update_date.should eq ""
-      pid.last_update_facility.should eq ""
-      pid.species_code.should eq ""
-      pid.breed_code.should eq ""
-      pid.strain.should eq ""
-      pid.production_class_code.should eq ""
-      pid.tribal_citizenship.should eq ""
+      expect(pid.set_id).to eq "1"
+      expect(pid.patient_id).to eq ""
+      expect(pid.patient_id_list).to eq "333"
+      expect(pid.alt_patient_id).to eq ""
+      expect(pid.patient_name).to eq "LastName^FirstName^MiddleInitial^SR^NickName"
+      expect(pid.mother_maiden_name).to eq ""
+      expect(pid.patient_dob).to eq "19760228"
+      expect(pid.admin_sex).to eq "F"
+      expect(pid.patient_alias).to eq ""
+      expect(pid.race).to eq "2106-3^White^HL70005^CAUC^Caucasian^L"
+      expect(pid.address).to eq ""
+      expect(pid.country_code).to eq ""
+      expect(pid.phone_home).to eq ""
+      expect(pid.phone_business).to eq ""
+      expect(pid.primary_language).to eq ""
+      expect(pid.marital_status).to eq ""
+      expect(pid.religion).to eq ""
+      expect(pid.account_number).to eq "555.55"
+      expect(pid.social_security_num).to eq "012345678"
+      expect(pid.driver_license_num).to eq ""
+      expect(pid.mothers_id).to eq ""
+      expect(pid.ethnic_group).to eq ""
+      expect(pid.birthplace).to eq ""
+      expect(pid.multi_birth).to eq ""
+      expect(pid.birth_order).to eq ""
+      expect(pid.citizenship).to eq ""
+      expect(pid.vet_status).to eq ""
+      expect(pid.nationality).to eq ""
+      expect(pid.death_date).to eq "201011110924-0700"
+      expect(pid.death_indicator).to eq "Y"
+      expect(pid.id_unknown_indicator).to eq ""
+      expect(pid.id_readability_code).to eq ""
+      expect(pid.last_update_date).to eq ""
+      expect(pid.last_update_facility).to eq ""
+      expect(pid.species_code).to eq ""
+      expect(pid.breed_code).to eq ""
+      expect(pid.strain).to eq ""
+      expect(pid.production_class_code).to eq ""
+      expect(pid.tribal_citizenship).to eq ""
     end
   end
 end

--- a/spec/prd_segment_spec.rb
+++ b/spec/prd_segment_spec.rb
@@ -7,23 +7,23 @@ describe HL7::Message::Segment::PRD do
     let (:prd) { HL7::Message::Segment::PRD.new base }
 
     it 'should set the provider_role' do
-      prd.provider_role.should eql 'RP'
+      expect(prd.provider_role).to eql 'RP'
     end
 
     it 'should set the name' do
-      prd.provider_name.should eql 'LastName^FirstName^MiddleInitial^SR^NickName'
+      expect(prd.provider_name).to eql 'LastName^FirstName^MiddleInitial^SR^NickName'
     end
 
     it 'should set the provider_address' do
-      prd.provider_address.should eql '444 Home Street^Apt B^Ann Arbor^MI^99999^USA'
+      expect(prd.provider_address).to eql '444 Home Street^Apt B^Ann Arbor^MI^99999^USA'
     end
 
     it 'should set the provider_location' do
-      prd.provider_location.should eql '^^^A Wonderful Clinic'
+      expect(prd.provider_location).to eql '^^^A Wonderful Clinic'
     end
 
     it 'should set provider_communication_information' do
-      prd.provider_communication_information.should eql '^WPN^PH^^^07^5555555'
+      expect(prd.provider_communication_information).to eql '^WPN^PH^^^07^5555555'
     end
   end
 end

--- a/spec/pv1_segment_spec.rb
+++ b/spec/pv1_segment_spec.rb
@@ -9,15 +9,15 @@ describe HL7::Message::Segment::PV1 do
 
     it 'allows access to an PV1 segment' do
       pv1 = HL7::Message::Segment::PV1.new @base
-      pv1.patient_class.should eq "R"
+      expect(pv1.patient_class).to eq "R"
     end
 
     it 'allows creation of an OBX segment' do
       pv1= HL7::Message::Segment::PV1.new
       pv1.referring_doctor="Smith^John"
-      pv1.referring_doctor.should eq "Smith^John"
+      expect(pv1.referring_doctor).to eq "Smith^John"
       pv1.admit_date = Date.new(2014, 1, 1)
-      pv1.admit_date.should eq '20140101'
+      expect(pv1.admit_date).to eq '20140101'
     end
   end
 end

--- a/spec/rf1_segment_spec.rb
+++ b/spec/rf1_segment_spec.rb
@@ -10,20 +10,20 @@ describe HL7::Message::Segment::RF1 do
 
     it 'allows access to an RF1 segment' do
       rf1 = HL7::Message::Segment::RF1.new @base
-      rf1.referral_status.should eq 'P^Pending^HL70283'
-      rf1.referral_priority.should eq 'R^Routine^HL70280'
-      rf1.referral_type.should eq 'GRF^General referral^HL70281'
-      rf1.referral_disposition.should eq 'AM^Assume management^HL70282'
-      rf1.originating_referral_identifier.should eq '8094'
-      rf1.effective_date.should eq '20060705'
-      rf1.process_date.should eq '20060705'
-      rf1.external_referral_identifier.should eq '42'
+      expect(rf1.referral_status).to eq 'P^Pending^HL70283'
+      expect(rf1.referral_priority).to eq 'R^Routine^HL70280'
+      expect(rf1.referral_type).to eq 'GRF^General referral^HL70281'
+      expect(rf1.referral_disposition).to eq 'AM^Assume management^HL70282'
+      expect(rf1.originating_referral_identifier).to eq '8094'
+      expect(rf1.effective_date).to eq '20060705'
+      expect(rf1.process_date).to eq '20060705'
+      expect(rf1.external_referral_identifier).to eq '42'
     end
 
     it 'allows creation of an RF1 segment' do
       rf1 = HL7::Message::Segment::RF1.new
       rf1.expiration_date=Date.new(2058, 12, 1)
-      rf1.expiration_date.should eq '20581201'
+      expect(rf1.expiration_date).to eq '20581201'
     end
   end
 end

--- a/spec/sch_segment_spec.rb
+++ b/spec/sch_segment_spec.rb
@@ -8,25 +8,25 @@ describe HL7::Message::Segment::SCH do
     end
 
     it 'creates an SCH segment' do
-      lambda do
+      expect do
         sch = HL7::Message::Segment::SCH.new( @base_sch )
-        sch.should_not be_nil
-        sch.to_s.should eq @base_sch
-      end.should_not raise_error
+        expect(sch).not_to be_nil
+        expect(sch.to_s).to eq @base_sch
+      end.not_to raise_error
     end
 
     it 'allows access to an SCH segment' do
-      lambda do
+      expect do
         sch = HL7::Message::Segment::SCH.new( @base_sch )
-        sch.schedule_id.should eq '681'
-        sch.event_reason.should eq 'S^SCHEDULED'
-        sch.appointment_reason.should eq '^BONE DENSITY PB,cf/RH '
-        sch.appointment_type.should eq '30^30 MINUTE APPOINTMENT'
-        sch.appointment_duration.should eq '45'
-        sch.appointment_duration_units.should eq 'm'
-        sch.entered_by_person.should eq 'polly^^POLLY BRESCOCK'
-        sch.filler_status_code.should eq 'SCHEDULED'
-      end.should_not raise_error
+        expect(sch.schedule_id).to eq '681'
+        expect(sch.event_reason).to eq 'S^SCHEDULED'
+        expect(sch.appointment_reason).to eq '^BONE DENSITY PB,cf/RH '
+        expect(sch.appointment_type).to eq '30^30 MINUTE APPOINTMENT'
+        expect(sch.appointment_duration).to eq '45'
+        expect(sch.appointment_duration_units).to eq 'm'
+        expect(sch.entered_by_person).to eq 'polly^^POLLY BRESCOCK'
+        expect(sch.filler_status_code).to eq 'SCHEDULED'
+      end.not_to raise_error
     end
   end
 end

--- a/spec/segment_field_spec.rb
+++ b/spec/segment_field_spec.rb
@@ -22,54 +22,54 @@ describe HL7::Message::Segment do
     it 'is evaluated on access by field name' do
       msg = MockSegment.new(@base)
 
-      msg.to_s.should       eq @base
-      msg.no_block.should   eq "no_block"
-      msg.validating.should eq "validated"
-      msg.converting.should eq "Xconverted"
+      expect(msg.to_s).to       eq @base
+      expect(msg.no_block).to   eq "no_block"
+      expect(msg.validating).to eq "validated"
+      expect(msg.converting).to eq "Xconverted"
 
       msg.no_block = "NO_BLOCK"
-      msg.no_block.should eq "NO_BLOCK"
+      expect(msg.no_block).to eq "NO_BLOCK"
 
       msg.validating = "good"
-      msg.validating.should eq "good"
+      expect(msg.validating).to eq "good"
       msg.validating = "bad"
-      msg.validating.should eq ""
+      expect(msg.validating).to eq ""
 
       msg.converting = "empty"
-      msg.converting.should eq "XXempty"
+      expect(msg.converting).to eq "XXempty"
     end
 
     it 'is not evaluated on read access by eXXX alias' do
       msg = MockSegment.new(@base)
 
-      msg.e1.should eq "no_block"
-      msg.e2.should eq "validated"
-      msg.e3.should eq "converted"
+      expect(msg.e1).to eq "no_block"
+      expect(msg.e2).to eq "validated"
+      expect(msg.e3).to eq "converted"
     end
 
     it 'is not evaluated on write access by eXXX alias' do
       msg = MockSegment.new(@base)
 
       msg.e1 = "NO_BLOCK"
-      msg.e1.should eq "NO_BLOCK"
+      expect(msg.e1).to eq "NO_BLOCK"
 
       msg.e2 = "good"
-      msg.e2.should eq "good"
+      expect(msg.e2).to eq "good"
       msg.e2 = "bad"
-      msg.e2.should eq "bad"
+      expect(msg.e2).to eq "bad"
 
       msg.e3 = "empty"
-      msg.e3.should eq "empty"
+      expect(msg.e3).to eq "empty"
     end
   end
 
   describe '#[]' do
     it 'allows index access to the segment' do
       msg = HL7::Message::Segment.new(@base)
-      msg[0].should eq 'Mock'
-      msg[1].should eq 'no_block'
-      msg[2].should eq 'validated'
-      msg[3].should eq 'converted'
+      expect(msg[0]).to eq 'Mock'
+      expect(msg[1]).to eq 'no_block'
+      expect(msg[2]).to eq 'validated'
+      expect(msg[3]).to eq 'converted'
     end
   end
 
@@ -85,8 +85,8 @@ describe HL7::Message::Segment do
     context 'with a valid field' do
       it 'uses alias field names' do
         msg = MockSegment.new(@base)
-        msg.no_block.should eq "no_block"
-        msg.no_block_alias.should eq "no_block"
+        expect(msg.no_block).to eq "no_block"
+        expect(msg.no_block_alias).to eq "no_block"
       end
     end
 
@@ -103,7 +103,7 @@ describe HL7::Message::Segment do
 
       it 'throws an error when the field is invalid' do
         msg = MockInvalidSegment.new(@base)
-        lambda{  msg.no_block_alias }.should raise_error
+        expect{  msg.no_block_alias }.to raise_error(HL7::InvalidDataError)
       end
     end
   end

--- a/spec/segment_generator_spec.rb
+++ b/spec/segment_generator_spec.rb
@@ -10,14 +10,14 @@ describe HL7::Message::SegmentGenerator do
     end
 
     it "should return true if @seg_parts is an array of one element or more" do
-      segment_generator.valid_segments_parts?.should be true
+      expect(segment_generator.valid_segments_parts?).to be true
     end
 
     context 'when is empty' do
       it "should return false if empty_segment_is_error is false" do
         segment_generator.seg_parts = nil
         HL7.ParserConfig[:empty_segment_is_error] = false
-        segment_generator.valid_segments_parts?.should be false
+        expect(segment_generator.valid_segments_parts?).to be false
       end
 
       it "should raise an error if empty_segment_is_error is true" do

--- a/spec/segment_list_storage_spec.rb
+++ b/spec/segment_list_storage_spec.rb
@@ -12,8 +12,8 @@ describe HL7::Message::SegmentListStorage do
     it "should allow to add a new segment type as child" do
       SegmentWithChildren.add_child_type :OBR
       segment = SegmentWithChildren.new
-      segment.accepts?(:OBR).should be true
-      segment.child_types.should include :OBR
+      expect(segment.accepts?(:OBR)).to be true
+      expect(segment.child_types).to include :OBR
     end
   end
 
@@ -21,7 +21,7 @@ describe HL7::Message::SegmentListStorage do
     subject do
       segment_instance = segment_class.new
       [:accepts?, :child_types, :children].each do |method|
-        segment_instance.respond_to?(method).should be true
+        expect(segment_instance.respond_to?(method)).to be true
       end
     end
 
@@ -30,7 +30,7 @@ describe HL7::Message::SegmentListStorage do
 
       it "by adding add_child_type should respond to the children methods" do
         segment_instance = segment_class.new
-        segment_instance.respond_to?(:children).should be false
+        expect(segment_instance.respond_to?(:children)).to be false
         segment_class.add_child_type(:OBR)
         subject
       end

--- a/spec/segment_spec.rb
+++ b/spec/segment_spec.rb
@@ -5,7 +5,7 @@ describe HL7::Message::Segment do
 
     it "should return the length of the elements" do
       segment = HL7::Message::Segment.new "MSA|AR|ZZ9380 ERR"
-      segment.length.should eq 3
+      expect(segment.length).to eq 3
     end
   end
 
@@ -16,14 +16,14 @@ describe HL7::Message::Segment do
       seg.each do |s|
         segment_count = segment_count + 1
       end
-      segment_count.should == seg.length
+      expect(segment_count).to eq(seg.length)
     end
   end
 
   describe 'is_child_segment?' do
     let(:segment){ HL7::Message::Segment.new "MSA|AR|ZZ9380 ERR" }
     it "return false when is not set" do
-      segment.is_child_segment?.should be false
+      expect(segment.is_child_segment?).to be false
     end
   end
 
@@ -32,7 +32,7 @@ describe HL7::Message::Segment do
     let(:formated_time){ time_now.strftime('%Y%m%d%H%M%S') }
 
     it "should conver to the hl7 time format" do
-      HL7::Message::Segment.convert_to_ts(time_now).should eq formated_time
+      expect(HL7::Message::Segment.convert_to_ts(time_now)).to eq formated_time
     end
   end
 end

--- a/spec/sft_segment_spec.rb
+++ b/spec/sft_segment_spec.rb
@@ -8,19 +8,19 @@ describe HL7::Message::Segment::SFT do
     end
 
     it 'creates an SFT segment' do
-      lambda do
+      expect do
         sft = HL7::Message::Segment::SFT.new( @base_sft )
-        sft.should_not be_nil
-        sft.to_s.should eq @base_sft
-      end.should_not raise_error
+        expect(sft).not_to be_nil
+        expect(sft.to_s).to eq @base_sft
+      end.not_to raise_error
     end
 
     it 'allows access to an SFT segment' do
-      lambda do
+      expect do
         sft = HL7::Message::Segment::SFT.new( @base_sft )
-        sft.software_product_name.should eq 'An Lab System'
-        sft.software_install_date.should eq '20080817'
-      end.should_not raise_error
+        expect(sft.software_product_name).to eq 'An Lab System'
+        expect(sft.software_install_date).to eq '20080817'
+      end.not_to raise_error
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,3 +10,4 @@ end
 # ruby-hl7 loads the rest of the files in lib
 require File.expand_path('../../lib/ruby-hl7', __FILE__)
 require File.expand_path('../../lib/test/hl7_messages', __FILE__)
+require 'pry'

--- a/spec/speed_parsing_spec.rb
+++ b/spec/speed_parsing_spec.rb
@@ -11,9 +11,9 @@ describe HL7::Message do
     it 'parses large, unknown segments rapidly' do
       start = Time.now
       doc = HL7::Message.new @msg
-      doc.should_not be_nil
+      expect(doc).not_to be_nil
       ends = Time.now
-      (ends-start).should be < 1
+      expect(ends-start).to be < 1
     end
   end
 end

--- a/spec/spm_segment_spec.rb
+++ b/spec/spm_segment_spec.rb
@@ -8,19 +8,19 @@ describe HL7::Message::Segment::SPM do
     end
 
     it 'creates an SPM segment' do
-      lambda do
+      expect do
         spm = HL7::Message::Segment::SPM.new( @base_spm )
-        spm.should_not be_nil
-        spm.to_s.should eq @base_spm
-      end.should_not raise_error
+        expect(spm).not_to be_nil
+        expect(spm.to_s).to eq @base_spm
+      end.not_to raise_error
     end
 
     it 'allows access to an SPM segment' do
-      lambda do
+      expect do
         spm = HL7::Message::Segment::SPM.new( @base_spm )
-        spm.specimen_type.should eq '122554006^Capillary blood specimen^SCT^BLDC^Blood capillary^HL70070^20080131^2.5.1'
-        spm.set_id.should eq '1'
-      end.should_not raise_error
+        expect(spm.specimen_type).to eq '122554006^Capillary blood specimen^SCT^BLDC^Blood capillary^HL70070^20080131^2.5.1'
+        expect(spm.set_id).to eq '1'
+      end.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
- Drop support for rubyforge
- Clean up Gemfile
- Update specs to newer rspec syntax.