### PR TITLE
Rename PID-12 from 'country_code' to 'county_code' per specification

### DIFF
--- a/lib/segments/pid.rb
+++ b/lib/segments/pid.rb
@@ -21,7 +21,7 @@ class HL7::Message::Segment::PID < HL7::Message::Segment
   add_field :patient_alias
   add_field :race
   add_field :address
-  add_field :country_code
+  add_field :county_code
   add_field :phone_home
   add_field :phone_business
   add_field :primary_language
@@ -53,4 +53,16 @@ class HL7::Message::Segment::PID < HL7::Message::Segment
   add_field :strain
   add_field :production_class_code
   add_field :tribal_citizenship
+
+  def country_code
+    warn "DEPRECATION WARNING: PID-12 is defined as 'county_code'; "+
+         "the 'country_code' alias is retained for backwards compatibility only."
+    county_code
+  end
+
+  def country_code=(country_code)
+    warn "DEPRECATION WARNING: PID-12 is defined as 'county_code'; "+
+         "the 'country_code' alias is retained for backwards compatibility only."
+    self.county_code = country_code
+  end
 end

--- a/spec/pid_segment_spec.rb
+++ b/spec/pid_segment_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe HL7::Message::Segment::PID do
   context 'general' do
     before :all do
-      @base = "PID|1||333||LastName^FirstName^MiddleInitial^SR^NickName||19760228|F||2106-3^White^HL70005^CAUC^Caucasian^L||||||||555.55|012345678||||||||||201011110924-0700|Y|||||||||"
+      @base = "PID|1||333||LastName^FirstName^MiddleInitial^SR^NickName||19760228|F||2106-3^White^HL70005^CAUC^Caucasian^L||AA||||||555.55|012345678||||||||||201011110924-0700|Y|||||||||"
     end
 
     it 'validates the admin_sex element' do
@@ -37,7 +37,7 @@ describe HL7::Message::Segment::PID do
       expect(pid.patient_alias).to eq ""
       expect(pid.race).to eq "2106-3^White^HL70005^CAUC^Caucasian^L"
       expect(pid.address).to eq ""
-      expect(pid.country_code).to eq ""
+      expect(pid.county_code).to eq "AA"
       expect(pid.phone_home).to eq ""
       expect(pid.phone_business).to eq ""
       expect(pid.primary_language).to eq ""
@@ -65,6 +65,14 @@ describe HL7::Message::Segment::PID do
       expect(pid.strain).to eq ""
       expect(pid.production_class_code).to eq ""
       expect(pid.tribal_citizenship).to eq ""
+    end
+
+    it "aliases the county_code field as country_code for backwards compatibility" do
+      pid = HL7::Message::Segment::PID.new @base
+      expect(pid.country_code).to eq "AA"
+
+      pid.country_code = "ZZ"
+      expect(pid.country_code).to eq "ZZ"
     end
   end
 end


### PR DESCRIPTION
The HL7 2.x specification defines PID-12 as County/Parish Code, but the gem names the field `:country_code`. I included a deprecation warning here to avoid confusion, but the name could also be aliased silently via `alias_field`.