### PR TITLE
change rake and rdoc to dev dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,6 @@ PATH
   remote: .
   specs:
     ruby-hl7 (1.3.0)
-      rake (~> 11.0)
-      rdoc (~> 3.12)
 
 GEM
   remote: https://rubygems.org/
@@ -49,10 +47,11 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.17)
   pry
+  rake (~> 11.0)
+  rdoc (~> 3.12)
   rspec (~> 2.99)
   ruby-hl7!
   simplecov (~> 0.15)
 
 BUNDLED WITH
    1.17.2
-   

--- a/ruby-hl7.gemspec
+++ b/ruby-hl7.gemspec
@@ -28,11 +28,10 @@ Gem::Specification.new do |s|
   s.summary = %q{Ruby HL7 Library}
   s.license = "MIT"
 
-  s.add_dependency 'rake', '~> 11.0'
-  s.add_dependency 'rdoc', '~> 3.12'
-
   s.add_development_dependency 'bundler', '~> 1.17'
-  s.add_development_dependency 'simplecov', '~> 0.15'
-  s.add_development_dependency 'rspec', '~> 2.99'
   s.add_development_dependency 'pry'
+  s.add_development_dependency 'rake', '~> 11.0'
+  s.add_development_dependency 'rdoc', '~> 3.12'
+  s.add_development_dependency 'rspec', '~> 2.99'
+  s.add_development_dependency 'simplecov', '~> 0.15'
 end


### PR DESCRIPTION
Noticed that Ruby-HL7 was forcing consumers to use a different rake version; I don't _think_ that's necessary so opting to change it (and rdoc).