### PR TITLE
modified gemspec to update rdoc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,8 +21,7 @@ GEM
       method_source (~> 0.9.0)
       spoon (~> 0.0)
     rake (11.3.0)
-    rdoc (3.12.2)
-      json (~> 1.4)
+    rdoc (6.2.0)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
@@ -48,7 +47,7 @@ DEPENDENCIES
   bundler (~> 1.17)
   pry
   rake (~> 11.0)
-  rdoc (~> 3.12)
+  rdoc (~> 6.1)
   rspec (~> 2.99)
   ruby-hl7!
   simplecov (~> 0.15)

--- a/ruby-hl7.gemspec
+++ b/ruby-hl7.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler', '~> 1.17'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '~> 11.0'
-  s.add_development_dependency 'rdoc', '~> 3.12'
+  s.add_development_dependency 'rdoc', '~> 6.1'
   s.add_development_dependency 'rspec', '~> 2.99'
   s.add_development_dependency 'simplecov', '~> 0.15'
 end


### PR DESCRIPTION
With recent gems, rdoc version 3.12 could not be installed, because it requires JSON ~> 1.4, that was not supported and could not build with its own library.
I updated rdoc version in gemspec to ~>6.1, and confirmed that happens no error with rspec.