### PR TITLE
pin older version of rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gemspec
+gem 'rake', '< 11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
       spoon (~> 0.0)
-    rake (11.3.0)
+    rake (10.5.0)
     rdoc (3.12.2)
       json (~> 1.4)
     rspec (2.99.0)
@@ -47,7 +47,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.17)
   pry
-  rake (~> 11.0)
+  rake (< 11.0)
   rdoc (~> 3.12)
   rspec (~> 2.99)
   ruby-hl7!


### PR DESCRIPTION
Travis is failing with a `NoMethodError: undefined method 'last_comment' for #<Rake::Application:0x0000000226f730>` message

[Stackoverflow](https://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11) says it's an issue with a new version of rake, so pinning the version will fix it for now