### PR TITLE
Chore/alias pid id reliability code to fix typo

### DIFF
--- a/lib/segments/pid.rb
+++ b/lib/segments/pid.rb
@@ -43,7 +43,7 @@ class HL7::Message::Segment::PID < HL7::Message::Segment
   end
   add_field :death_indicator
   add_field :id_unknown_indicator
-  add_field :id_readability_code
+  add_field :id_reliability_code
   add_field :last_update_date do |value|
     convert_to_ts(value)
   end
@@ -64,5 +64,17 @@ class HL7::Message::Segment::PID < HL7::Message::Segment
     warn "DEPRECATION WARNING: PID-12 is defined as 'county_code'; "+
          "the 'country_code' alias is retained for backwards compatibility only."
     self.county_code = country_code
+  end
+
+  def id_readability_code
+    warn "DEPRECATION WARNING: PID-32 is defined as 'id_reliability_code'; "+
+         "the 'id_readability_code' alias is retained for backwards compatibility only."
+    id_reliability_code
+  end
+
+  def id_readability_code=(code)
+    warn "DEPRECATION WARNING: PID-32 is defined as 'id_reliability_code'; "+
+           "the 'id_readability_code' alias is retained for backwards compatibility only."
+    self.id_reliability_code = code
   end
 end

--- a/spec/pid_segment_spec.rb
+++ b/spec/pid_segment_spec.rb
@@ -2,77 +2,94 @@
 require 'spec_helper'
 
 describe HL7::Message::Segment::PID do
-  context 'general' do
-    before :all do
-      @base = "PID|1||333||LastName^FirstName^MiddleInitial^SR^NickName||19760228|F||2106-3^White^HL70005^CAUC^Caucasian^L||AA||||||555.55|012345678||||||||||201011110924-0700|Y|||||||||"
+  let(:segment) {
+    "PID|1||333||LastName^FirstName^MiddleInitial^SR^NickName||19760228|F||2106-3^White^HL70005^CAUC^Caucasian^L||AA||||||555.55|012345678||||||||||201011110924-0700|Y||UA|||||||"
+  }
+  let(:filled_pid) { HL7::Message::Segment::PID.new(segment) }
+
+  context '.initialize' do
+    it 'sets values correctly' do
+      expect(filled_pid.set_id).to eq "1"
+      expect(filled_pid.patient_id).to eq ""
+      expect(filled_pid.patient_id_list).to eq "333"
+      expect(filled_pid.alt_patient_id).to eq ""
+      expect(filled_pid.patient_name).to eq "LastName^FirstName^MiddleInitial^SR^NickName"
+      expect(filled_pid.mother_maiden_name).to eq ""
+      expect(filled_pid.patient_dob).to eq "19760228"
+      expect(filled_pid.admin_sex).to eq "F"
+      expect(filled_pid.patient_alias).to eq ""
+      expect(filled_pid.race).to eq "2106-3^White^HL70005^CAUC^Caucasian^L"
+      expect(filled_pid.address).to eq ""
+      expect(filled_pid.county_code).to eq "AA"
+      expect(filled_pid.phone_home).to eq ""
+      expect(filled_pid.phone_business).to eq ""
+      expect(filled_pid.primary_language).to eq ""
+      expect(filled_pid.marital_status).to eq ""
+      expect(filled_pid.religion).to eq ""
+      expect(filled_pid.account_number).to eq "555.55"
+      expect(filled_pid.social_security_num).to eq "012345678"
+      expect(filled_pid.driver_license_num).to eq ""
+      expect(filled_pid.mothers_id).to eq ""
+      expect(filled_pid.ethnic_group).to eq ""
+      expect(filled_pid.birthplace).to eq ""
+      expect(filled_pid.multi_birth).to eq ""
+      expect(filled_pid.birth_order).to eq ""
+      expect(filled_pid.citizenship).to eq ""
+      expect(filled_pid.vet_status).to eq ""
+      expect(filled_pid.nationality).to eq ""
+      expect(filled_pid.death_date).to eq "201011110924-0700"
+      expect(filled_pid.death_indicator).to eq "Y"
+      expect(filled_pid.id_unknown_indicator).to eq ""
+      expect(filled_pid.id_reliability_code).to eq "UA"
+      expect(filled_pid.last_update_date).to eq ""
+      expect(filled_pid.last_update_facility).to eq ""
+      expect(filled_pid.species_code).to eq ""
+      expect(filled_pid.breed_code).to eq ""
+      expect(filled_pid.strain).to eq ""
+      expect(filled_pid.production_class_code).to eq ""
+      expect(filled_pid.tribal_citizenship).to eq ""
+    end
+  end
+
+  describe '#country_code' do
+    it "aliases the county_code field as country_code for backward compatibility" do
+      expect(filled_pid.country_code).to eq "AA"
+
+      filled_pid.country_code = "ZZ"
+      expect(filled_pid.country_code).to eq "ZZ"
+    end
+  end
+
+  describe '#id_readability_code='  do
+    it "aliases the id_reliability_code field as id_readability_code for backward compatibility" do
+      expect(filled_pid.id_readability_code).to eq "UA"
+
+      filled_pid.id_readability_code = "AL"
+      expect(filled_pid.id_reliability_code).to eq "AL"
+    end
+  end
+
+  describe '#admin_sex=' do
+    context 'when admin_sex is filled with an invalid value' do
+      it 'raises an InvalidDataError' do
+        expect do
+          ["TEST", "A", 1, 2].each do |x|
+            filled_pid.admin_sex = x
+          end
+        end.to raise_error(HL7::InvalidDataError)
+      end
     end
 
-    it 'validates the admin_sex element' do
-      pid = HL7::Message::Segment::PID.new
-      expect do
-        vals = %w[F M O U A N C] + [ nil ]
-        vals.each do |x|
-          pid.admin_sex = x
-        end
-        pid.admin_sex = ""
-      end.not_to raise_error
-
-      expect do
-        ["TEST", "A", 1, 2].each do |x|
-          pid.admin_sex = x
-        end
-      end.to raise_error(HL7::InvalidDataError)
-    end
-
-    it "sets values correctly" do
-      pid = HL7::Message::Segment::PID.new @base
-      expect(pid.set_id).to eq "1"
-      expect(pid.patient_id).to eq ""
-      expect(pid.patient_id_list).to eq "333"
-      expect(pid.alt_patient_id).to eq ""
-      expect(pid.patient_name).to eq "LastName^FirstName^MiddleInitial^SR^NickName"
-      expect(pid.mother_maiden_name).to eq ""
-      expect(pid.patient_dob).to eq "19760228"
-      expect(pid.admin_sex).to eq "F"
-      expect(pid.patient_alias).to eq ""
-      expect(pid.race).to eq "2106-3^White^HL70005^CAUC^Caucasian^L"
-      expect(pid.address).to eq ""
-      expect(pid.county_code).to eq "AA"
-      expect(pid.phone_home).to eq ""
-      expect(pid.phone_business).to eq ""
-      expect(pid.primary_language).to eq ""
-      expect(pid.marital_status).to eq ""
-      expect(pid.religion).to eq ""
-      expect(pid.account_number).to eq "555.55"
-      expect(pid.social_security_num).to eq "012345678"
-      expect(pid.driver_license_num).to eq ""
-      expect(pid.mothers_id).to eq ""
-      expect(pid.ethnic_group).to eq ""
-      expect(pid.birthplace).to eq ""
-      expect(pid.multi_birth).to eq ""
-      expect(pid.birth_order).to eq ""
-      expect(pid.citizenship).to eq ""
-      expect(pid.vet_status).to eq ""
-      expect(pid.nationality).to eq ""
-      expect(pid.death_date).to eq "201011110924-0700"
-      expect(pid.death_indicator).to eq "Y"
-      expect(pid.id_unknown_indicator).to eq ""
-      expect(pid.id_readability_code).to eq ""
-      expect(pid.last_update_date).to eq ""
-      expect(pid.last_update_facility).to eq ""
-      expect(pid.species_code).to eq ""
-      expect(pid.breed_code).to eq ""
-      expect(pid.strain).to eq ""
-      expect(pid.production_class_code).to eq ""
-      expect(pid.tribal_citizenship).to eq ""
-    end
-
-    it "aliases the county_code field as country_code for backwards compatibility" do
-      pid = HL7::Message::Segment::PID.new @base
-      expect(pid.country_code).to eq "AA"
-
-      pid.country_code = "ZZ"
-      expect(pid.country_code).to eq "ZZ"
+    context 'when admin_sex is filled with a valid value' do
+      it 'does not raise any error' do
+        expect do
+          vals = %w[F M O U A N C] + [ nil ]
+          vals.each do |x|
+            filled_pid.admin_sex = x
+          end
+          filled_pid.admin_sex = ""
+        end.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
# Description

This PR fixes a typo on the PID segment, where the `PID-32` attribute was defined as `id_readability_code` instead of `id_reliability_code` as mentioned in the [Caristix HL7 documentation](https://hl7-definition.caristix.com/v2/HL7v2.6/Segments/PID).

_Note: This is my first contribution to this repo, hence its simplicity. Should it be reviewed by the community, I would be happy to contribute more and help revamp some parts of this nice gem that deserve to be updated. Please let me know! :)_