### PR TITLE
Chore: Add first Github Action for Rspec workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - head
+          - '3.3'
+          - '3.2'
+          - '3.1'
+          - '3.0'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby version ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # 'bundle install' and cache
+      - name: Run tests
+        run: bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,52 +6,47 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.1.2)
-    diff-lcs (1.3)
-    docile (1.3.2)
-    ffi (1.12.2-java)
-    json (2.5.1)
-    json (2.5.1-java)
-    method_source (0.9.2)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    pry (0.12.2-java)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-      spoon (~> 0.0)
-    rake (13.0.1)
+    coderay (1.1.3)
+    diff-lcs (1.5.1)
+    docile (1.4.1)
+    json (2.7.2)
+    method_source (1.1.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    psych (5.1.2)
+      stringio
+    rake (13.2.1)
     rake-contrib (1.0.0)
       rake
-    rdoc (6.3.1)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.1)
-      rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.0)
+    rdoc (6.7.0)
+      psych (>= 4.0.0)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.1)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.2)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    spoon (0.0.6)
-      ffi
+    stringio (3.1.1)
 
 PLATFORMS
-  java
+  arm64-darwin-23
   ruby
-  x86-mingw32
 
 DEPENDENCIES
-  bundler (~> 1.17)
+  bundler (~> 2.5)
   pry
   rake (>= 12.3.3)
   rake-contrib
@@ -62,4 +57,4 @@ DEPENDENCIES
   simplecov-html (~> 0.10.0)
 
 BUNDLED WITH
-   1.17.2
+   2.5.16

--- a/ruby-hl7.gemspec
+++ b/ruby-hl7.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.summary = %q{Ruby HL7 Library}
   s.license = "MIT"
 
-  s.add_development_dependency 'bundler', '~> 1.17'
+  s.add_development_dependency 'bundler', '~> 2.5'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '>= 12.3.3'
   s.add_development_dependency 'rdoc', '~> 6.3'


### PR DESCRIPTION
# Description

This PR adds a 'Github Actions' CI workflow, running the project RSpec test suite on a panel of Ruby versions, as mentioned in [this comment](https://github.com/ruby-hl7/ruby-hl7/pull/124#issuecomment-2393688053) by @Stratus3D .

_Note: This PR simply adds an arbitrary minimal CI config; I intend to add some relevant workflows (rubocop at least, for a start) in upcoming PRs_