### PR TITLE
chore: remove 'C' value from PID segment validation spec

### DIFF
--- a/spec/pid_segment_spec.rb
+++ b/spec/pid_segment_spec.rb
@@ -83,7 +83,7 @@ describe HL7::Message::Segment::PID do
     context 'when admin_sex is filled with a valid value' do
       it 'does not raise any error' do
         expect do
-          vals = %w[F M O U A N C] + [ nil ]
+          vals = %w[F M O U A N] + [ nil ]
           vals.each do |x|
             filled_pid.admin_sex = x
           end


### PR DESCRIPTION
# Description

Just a tiny validation test case removal, mentioned [here](https://github.com/ruby-hl7/ruby-hl7/pull/128#discussion_r1787660401).