### PR TITLE
Chore: Add helpers for date-formatting

### DIFF
--- a/lib/helpers/time_formatter_helper.rb
+++ b/lib/helpers/time_formatter_helper.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module TimeFormatterHelper
+  class ValueTypeNotSupportedError < StandardError; end
+
+  # Get an HL7 timestamp (type TS) for a Time or DateTime instance.
+  #
+  # fraction_digits:: specifies a number of digits of fractional seconds.
+  #                   Its default value is 0.
+  #  hl7_formatted_timestamp(Time.parse('01:23'))
+  #  => "20091202012300"
+  #  hl7_formatted_timestamp(Time.now, 3)
+  #  => "20091202153652.302"
+  def hl7_formatted_timestamp(value, fraction_digits = 0)
+    raise ValueTypeNotSupportedError, "Value must be an instance of Time or DateTime" unless value.is_a?(Time) || value.is_a?(DateTime)
+
+    value.strftime("%Y%m%d%H%M%S") + hl7_formatted_fractions(value, fraction_digits)
+  end
+
+  # Get an HL7 timestamp (type TS) for a Date instance.
+  def hl7_formatted_date(value)
+    raise ValueTypeNotSupportedError, "Value must be an instance of Date" unless value.is_a?(Date)
+
+    value.strftime("%Y%m%d")
+  end
+
+private
+
+  def hl7_formatted_fractions(value, fraction_digits = 0)
+    return "" unless fraction_digits.positive?
+
+    time_fraction =  if value.respond_to?(:usec)
+      value.usec
+    else
+      value.sec_fraction.to_f * 1_000_000
+    end
+
+    answer = ".#{format("%06d", time_fraction)}"
+    answer += "0" * ((fraction_digits - 6)).abs if fraction_digits > 6
+    answer[0, 1 + fraction_digits]
+  end
+end

--- a/lib/ruby-hl7.rb
+++ b/lib/ruby-hl7.rb
@@ -21,6 +21,7 @@ require "rubygems"
 require "stringio"
 require "date"
 require "configuration"
+require "helpers/time_formatter_helper"
 
 module HL7 # :nodoc:
   VERSION = "1.3.3"

--- a/lib/segment.rb
+++ b/lib/segment.rb
@@ -193,6 +193,12 @@ private
   end
 
   def self.convert_to_ts(value) # :nodoc:
-    value.respond_to?(:to_hl7) ? value.to_hl7 : value
+    if value.is_a?(Time) || value.is_a?(DateTime)
+      hl7_formatted_timestamp(value)
+    elsif value.is_a?(Date)
+      hl7_formatted_date(value)
+    else
+      value
+    end
   end
 end

--- a/lib/segment.rb
+++ b/lib/segment.rb
@@ -21,6 +21,8 @@
 #
 class HL7::Message::Segment
   extend HL7::Message::SegmentListStorage
+  extend TimeFormatterHelper
+
   include HL7::Message::SegmentFields
 
   attr_accessor :segment_parent

--- a/lib/segments/dg1.rb
+++ b/lib/segments/dg1.rb
@@ -26,13 +26,5 @@ module HL7
     add_field :attestation_date_time do |value|
       convert_to_ts(value)
     end
-
-    def self.convert_to_ts(value) # :nodoc:
-      if value.is_a?(Time) || value.is_a?(Date)
-        value.to_hl7
-      else
-        value
-      end
-    end
   end
 end

--- a/lib/segments/prt.rb
+++ b/lib/segments/prt.rb
@@ -20,10 +20,4 @@ class HL7::Message::Segment::PRT < HL7::Message::Segment
   add_field :participation_qualitative_duration, :idx => 13
   add_field :participation_address, :idx => 14
   add_field :participation_telecommunication_address, :idx => 15
-
-  def self.convert_to_ts(value)
-    return value.to_hl7 if value.is_a?(Time) || value.is_a?(Date)
-
-    value
-  end
 end

--- a/spec/helpers/time_formatter_helper_spec.rb
+++ b/spec/helpers/time_formatter_helper_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe TimeFormatterHelper, :type => :helper do
+  describe "#hl7_formatted_timestamp" do
+    subject(:formatted_date) { hl7_formatted_timestamp(value, fraction_digits) }
+
+    let(:fraction_digits) { 0 }
+
+    context "when value is not a Time nor a DateTime" do
+      let(:value) { Date.today }
+
+      it "raises a ValueTypeNotSupportedError" do
+        expect { formatted_date }.to raise_error(TimeFormatterHelper::ValueTypeNotSupportedError)
+      end
+    end
+
+    context "when value is a Time" do
+      let(:value) { Time.now }
+
+      context "when fraction_digits is 0 (default value)" do
+        it "returns the expected formatted string" do
+          expect(formatted_date).to eq(value.strftime("%Y%m%d%H%M%S"))
+        end
+      end
+
+      context "when fraction_digits is given" do
+        let(:fraction_digits) { 9 }
+        let(:fraction9) { ".#{format("%06d", value.to_time.usec)}#{"0" * 3}" }
+
+        it "returns the expected formatted string" do
+          expect(formatted_date).to eq(value.strftime("%Y%m%d%H%M%S") + fraction9)
+        end
+      end
+    end
+
+    context "when value is a DateTime" do
+      let(:value) { DateTime.now }
+
+      context "when fraction_digits is 0 (default value)" do
+        it "returns the expected formatted string" do
+          expect(formatted_date).to eq(value.strftime("%Y%m%d%H%M%S"))
+        end
+      end
+
+      context "when fraction_digits is given" do
+        let(:fraction_digits) { 3 }
+        let(:fraction3) { ".#{format("%06d", value.to_time.usec)[0, 3]}" }
+
+        it "returns the expected formatted string" do
+          expect(formatted_date).to eq(value.strftime("%Y%m%d%H%M%S") + fraction3)
+        end
+      end
+    end
+  end
+
+  describe "#hl7_formatted_date" do
+    subject(:formatted_date) { hl7_formatted_date(value) }
+
+    context "when value is not a Date" do
+      let(:value) { Time.new }
+
+      it "raises a ValueTypeNotSupportedError" do
+        expect { formatted_date }.to raise_error(TimeFormatterHelper::ValueTypeNotSupportedError)
+      end
+    end
+
+    context "when value is a Date" do
+      let(:value) { Date.today }
+
+      it "returns the expected formatted string" do
+        expect(formatted_date).to eq(value.strftime("%Y%m%d"))
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,7 @@ end
 require File.expand_path("../lib/ruby-hl7", __dir__)
 require File.expand_path("../lib/test/hl7_messages", __dir__)
 require "pry"
+
+RSpec.configure do |config|
+  config.include TimeFormatterHelper, :type => :helper
+end


### PR DESCRIPTION
# Description
Historically, HL7-related date-formatting was done with the help of a [monkey-patch](https://github.com/ruby-hl7/ruby-hl7/blob/eb69e499b288056d08ad3a347874e42d632eec76/lib/core_ext/date_time.rb#L3) of `Date`, `DateTime` and `Time` classes that defines a custom `to_hl7` method to them.
This PR introduces a helper for this exact purpose and replaces usages of the monkey-patched methods throughout the gem's codebase.

In a further PR, I suggest we deprecate the `to_hl7` methods and add instructions to the README on how to use these helpers instead.

# Commit breakdown
* chore: Add new helper TimeFormatterHelper defining formatting methods for time objects
* chore: load new helper globally, add extend statement in HL7::Message::Segment
* chore: (HL7::Message::Segment) Update .convert_to_ts method to use time-formatting helper instead of monkey-patched methods
* chore: Remove overwritten .convert_to_ts methods in segment classes