### PR TITLE
Chore: Add helper for string-formatting

### DIFF
--- a/lib/helpers/string_formatter_helper.rb
+++ b/lib/helpers/string_formatter_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module StringFormatterHelper
+  def hl7_batch?(string)
+    string.match?(/^FHS/)
+  end
+end

--- a/lib/message_parser.rb
+++ b/lib/message_parser.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 module HL7::MessageBatchParser
+  include StringFormatterHelper
+
   def parse_batch(batch) # :yields: message
-    raise HL7::ParseError, "badly_formed_batch_message" unless
-      batch.hl7_batch?
+    raise HL7::ParseError, "badly_formed_batch_message" unless hl7_batch?(batch)
 
     batch = clean_batch_for_jruby batch
 

--- a/lib/ruby-hl7.rb
+++ b/lib/ruby-hl7.rb
@@ -22,6 +22,7 @@ require "stringio"
 require "date"
 require "configuration"
 require "helpers/time_formatter_helper"
+require "helpers/string_formatter_helper"
 
 module HL7 # :nodoc:
   VERSION = "1.3.3"

--- a/spec/batch_parsing_spec.rb
+++ b/spec/batch_parsing_spec.rb
@@ -31,23 +31,3 @@ describe HL7::Message do
     end
   end
 end
-
-describe "String extension" do
-  before :all do
-    @batch_message = HL7MESSAGES[:realm_batch]
-    @plain_message = HL7MESSAGES[:realm_minimal_message]
-  end
-
-  it "respond_toes :hl7_batch?" do
-    expect(@batch_message.hl7_batch?).to be true
-    expect(@plain_message).to respond_to(:hl7_batch?)
-  end
-
-  it "returns true when passed a batch message" do
-    expect(@batch_message).to be_an_hl7_batch
-  end
-
-  it "returns false when passed a plain message" do
-    expect(@plain_message).not_to be_an_hl7_batch
-  end
-end

--- a/spec/helpers/string_formatter_spec.rb
+++ b/spec/helpers/string_formatter_spec.rb
@@ -4,18 +4,18 @@ require "spec_helper"
 
 RSpec.describe StringFormatterHelper, :type => :helper do
   describe "#hl7_batch?" do
-    context 'when string has a batch identifier' do
+    context "when string has a batch identifier" do
       let(:string) { HL7MESSAGES[:realm_batch] }
 
-      it 'returns true' do
+      it "returns true" do
         expect(hl7_batch?(string)).to be true
       end
     end
 
-    context 'when string does not have a batch identifier' do
+    context "when string does not have a batch identifier" do
       let(:string) { HL7MESSAGES[:realm_minimal_message] }
 
-      it 'returns false' do
+      it "returns false" do
         expect(hl7_batch?(string)).to be false
       end
     end

--- a/spec/helpers/string_formatter_spec.rb
+++ b/spec/helpers/string_formatter_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe StringFormatterHelper, :type => :helper do
+  describe "#hl7_batch?" do
+    context 'when string has a batch identifier' do
+      let(:string) { HL7MESSAGES[:realm_batch] }
+
+      it 'returns true' do
+        expect(hl7_batch?(string)).to be true
+      end
+    end
+
+    context 'when string does not have a batch identifier' do
+      let(:string) { HL7MESSAGES[:realm_minimal_message] }
+
+      it 'returns false' do
+        expect(hl7_batch?(string)).to be false
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,4 +16,5 @@ require "pry"
 
 RSpec.configure do |config|
   config.include TimeFormatterHelper, :type => :helper
+  config.include StringFormatterHelper, :type => :helper
 end


### PR DESCRIPTION
# Description
Historically, HL7-related string-formatting was done with the help of a [monkey-patch](https://github.com/ruby-hl7/ruby-hl7/blob/eb69e499b288056d08ad3a347874e42d632eec76/lib/core_ext/date_time.rb#L3) of the `String` method that defines an `hl7_batch?` method.
This PR introduces a helper for this exact purpose and replaces usages of the monkey-patched methods throughout the gem's codebase, in the same fashion as what was done [here](https://github.com/ruby-hl7/ruby-hl7/pull/135).

In a further PR, I suggest we deprecate the `hl7_batch?` method and add instructions to the README on how to use these helpers instead.