### PR TITLE
[skip-ci] Remove domains from maintainers list. Reason: domainsnot longer active

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ The gem's version id can be found in the `HL7::VERSION` constant.
 
 ### Maintained by:
 
-* http://csinitiative.com
-* http://trisano.org
 * http://github.com/csinitiative/trisano
 * http://onemedical.com
 


### PR DESCRIPTION


# Description

these domains are not longer working

- csinitiative.com
- trisano.org
# Checklist

- [x] 💡 The PR has a concise and explicit title
- [x] 📝 The PR contains a clear description of the changes
- [ ] 🧪 There are unit tests that prove that the fix is effective or that the feature works
