### PR TITLE
feat: Add #children_list method to Segment, returning [] in case no c…

### DIFF
--- a/lib/segment.rb
+++ b/lib/segment.rb
@@ -162,6 +162,11 @@ class HL7::Message::Segment
     respond_to?(:children)
   end
 
+  def children_list
+    # NOTE: this method is meant to replace #children. In order to avoid a breaking change, we will keep both methods for now.
+    has_children? ? children(:mute_deprecation_warning => true) : []
+  end
+
 private
 
   def self.singleton # :nodoc:

--- a/lib/segment_list_storage.rb
+++ b/lib/segment_list_storage.rb
@@ -43,8 +43,10 @@ private
 
   def define_method_children
     class_eval do
-      define_method(:children) do
+      define_method(:children) do |mute_deprecation_warning: false|
         unless defined?(@my_children)
+          warn "#children method is deprecated. Please use #children_list instead." unless mute_deprecation_warning
+
           p = self
           @my_children ||= []
           @my_children.instance_eval do

--- a/spec/segment_spec.rb
+++ b/spec/segment_spec.rb
@@ -29,6 +29,25 @@ describe HL7::Message::Segment do
     end
   end
 
+  describe "#children_list" do
+    context "when segment class has children" do
+      let(:message) { HL7::Message.new(open("./test_data/obxobr.hl7").readlines) }
+
+      it "returns the children list" do
+        expect(message[:OBR].first.children_list).to be_a(Array)
+        expect(message[:OBR].first.children_list.map(&:class)).to contain_exactly(HL7::Message::Segment::NTE, HL7::Message::Segment::OBX, HL7::Message::Segment::OBX, HL7::Message::Segment::OBX, HL7::Message::Segment::OBX, HL7::Message::Segment::OBX)
+      end
+    end
+
+    context "when segment class does not have children" do
+      let(:segment) { HL7::Message::Segment::TXA.new "TXA|1|AR|AP|20220611113300|1^Name|20220611|2022061110||1^Creator|" }
+
+      it "returns an empty array" do
+        expect(segment.children_list).to eq []
+      end
+    end
+  end
+
   describe "convert_to_ts" do
     let(:time_now) { DateTime.now }
     let(:formated_time) { time_now.strftime("%Y%m%d%H%M%S") }


### PR DESCRIPTION
# Description

Fixes https://github.com/ruby-hl7/ruby-hl7/issues/39
This PR adds a silent `#children_list` method to avoid raising an error when children are not defined on a particular segment, as suggested in [this comment](https://github.com/ruby-hl7/ruby-hl7/issues/39#issuecomment-71588130).

# Checklist

- [x] 💡 The PR has a concise and explicit title
- [x] 📝 The PR contains a clear description of the changes
- [x] 🧪 There are unit tests that prove that the fix is effective or that the feature works
