### PR TITLE
Chore: Add #repond_to_missing? to Segment method overrides

### DIFF
--- a/lib/segment.rb
+++ b/lib/segment.rb
@@ -117,6 +117,13 @@ class HL7::Message::Segment
     end
   end
 
+  def respond_to_missing?(method_name, include_private = false)
+    base_str = method_name.to_s.delete("=")
+    base_sym = base_str.to_sym
+
+    self.class.fields.include?(base_sym) || (/e([0-9]+)/ =~ base_str)&.positive? || super
+  end
+
   # sort-compare two Segments, 0 indicates equality
   def <=>(other)
     return nil unless other.is_a?(HL7::Message::Segment)


### PR DESCRIPTION
Fixes https://github.com/ruby-hl7/ruby-hl7/issues/42

# Description

This PR simply defines a `respond_to_missing?` custom method to match the behaviour of the `#method_missing` defined in this specific class.

# Checklist

- [x] 💡 The PR has a concise and explicit title
- [x] 📝 The PR contains a clear description of the changes
- [x] 🧪 There are unit tests that prove that the fix is effective or that the feature works
